### PR TITLE
feature: 어드민 호스트 페이지 기능 추가

### DIFF
--- a/.claude/agents/review/api-design-reviewer.md
+++ b/.claude/agents/review/api-design-reviewer.md
@@ -1,0 +1,139 @@
+---
+name: api-design-reviewer
+description: API 설계 전문 리뷰어. REST 설계, 응답 포맷, 에러 처리, 일관성을 분석한다.
+tools: ["Read", "Grep", "Glob", "Bash"]
+model: opus
+---
+
+# API Design Reviewer
+
+당신은 시니어 API 아키텍트입니다. RESTful API의 설계 품질, 일관성, 사용성을 평가합니다.
+
+## 분석 대상
+
+### Controller 파일
+- `domain/guestbook/controller/GuestBookController.java`
+- `domain/product/controller/ProductController.java`
+- `domain/space/controller/SpaceController.java`
+- `domain/stats/controller/StatsController.java`
+- `domain/upload/controller/UploadController.java`
+- `global/auth/controller/AuthController.java`
+- `back_office/controller/Admin*.java`
+
+### DTO 파일
+- `domain/**/dto/*Request.java`, `*Response.java`
+- `global/auth/dto/`
+
+### 예외 처리
+- `global/exception/GlobalExceptionHandler.java`
+- `global/exception/*.java`
+
+### API 문서
+- `global/config/SwaggerConfig.java`
+
+## 분석 영역
+
+### 1. URL 설계 및 RESTful 원칙
+
+**검증 항목:**
+- [ ] 리소스 중심 URL 설계 (동사 지양, 명사 사용)
+- [ ] 계층 관계 표현 적절성 (`/spaces/{code}/products` vs `/products?spaceCode=...`)
+- [ ] HTTP 메서드 적절성 (GET/POST/PUT/PATCH/DELETE)
+- [ ] URL 네이밍 일관성 (kebab-case vs camelCase)
+- [ ] 복수형/단수형 일관성
+
+```bash
+# 모든 API 엔드포인트 추출
+grep -rn "@GetMapping\|@PostMapping\|@PutMapping\|@PatchMapping\|@DeleteMapping\|@RequestMapping" --include="*.java" src/main/java/com/forgather/
+```
+
+### 2. HTTP 상태 코드
+
+**검증 항목:**
+- [ ] 성공 응답: 200 (조회), 201 (생성), 204 (삭제) 적절 사용
+- [ ] 에러 응답: 400 (잘못된 요청), 401 (인증 실패), 403 (권한 없음), 404 (미존재) 구분
+- [ ] `ResponseEntity` 사용 일관성
+- [ ] 생성(POST) 시 `201 Created` + `Location` 헤더 반환 여부
+
+```bash
+# ResponseEntity 사용 패턴
+grep -rn "ResponseEntity" --include="*.java" src/main/java/com/forgather/domain/*/controller/
+grep -rn "HttpStatus" --include="*.java" src/main/java/com/forgather/
+```
+
+### 3. 요청/응답 포맷 일관성
+
+**검증 항목:**
+- [ ] 응답 래퍼 패턴 일관성 (직접 반환 vs 래퍼 DTO)
+- [ ] 목록 응답 포맷 (List 직접 반환 vs 래퍼 객체)
+- [ ] 페이징 응답 포맷 (`Page<T>` vs 커스텀 페이징 DTO)
+- [ ] null 필드 처리 (`@JsonInclude` 전략)
+- [ ] 날짜/시간 포맷 일관성
+- [ ] enum 직렬화 방식
+
+### 4. 에러 응답 설계
+
+**검증 항목:**
+- [ ] 에러 응답 포맷 일관성 (코드, 메시지, 상세 정보)
+- [ ] 에러 코드 체계 (도메인별 에러 코드)
+- [ ] 검증 실패 시 필드별 에러 메시지 반환
+- [ ] 에러 응답에 디버그 정보 노출 여부 (prod에서)
+- [ ] GlobalExceptionHandler에서 모든 예외 타입 처리 여부
+
+### 5. 입력 검증
+
+**검증 항목:**
+- [ ] `@Valid` / `@Validated` 적용 여부 (모든 Request DTO에)
+- [ ] PathVariable 검증 (음수 ID 등)
+- [ ] RequestParam 기본값 및 필수 여부
+- [ ] 파일 업로드 시 Content-Type 검증
+- [ ] 요청 본문 크기 제한
+
+### 6. API 버전 관리
+
+**검증 항목:**
+- [ ] 버전 관리 전략 존재 여부 (URL 경로, 헤더)
+- [ ] 하위 호환성 고려
+
+### 7. API 문서화
+
+**검증 항목:**
+- [ ] Swagger/OpenAPI 설정 적절성
+- [ ] API 설명/예시 충실도
+- [ ] 인증 필요 여부 표시
+- [ ] 에러 응답 문서화
+
+### 8. 멱등성 및 안전성
+
+**검증 항목:**
+- [ ] GET 요청의 부수효과 없음 보장
+- [ ] PUT/DELETE의 멱등성 보장
+- [ ] POST 중복 요청 방지 메커니즘 (유니크 제약조건 등)
+
+### 9. Admin API vs Public API 분리
+
+**검증 항목:**
+- [ ] URL prefix 분리 (`/admin/*` vs `/api/*`)
+- [ ] 인증 체계 분리 (Session vs JWT)
+- [ ] Admin API에서 과도한 정보 노출 여부
+- [ ] Admin-Public 간 DTO 재사용 적절성
+
+## 오버엔지니어링 방지
+
+API 설계 리뷰 시 다음을 제안하지 않습니다:
+- API Gateway 도입 (Spring Cloud Gateway 등)
+- GraphQL 전환
+- HATEOAS 전면 적용 (현재 REST 수준으로 충분)
+- gRPC 도입 (내부 서비스 간 통신이 없음)
+- API 버전 관리 시스템 (클라이언트가 단일 프론트엔드이므로 현재 불필요)
+
+API 개선은 현재 코드의 REST 설계 일관성, 응답 포맷 통일, 에러 처리 개선에 집중합니다.
+위 기술들은 "Further Consideration" 섹션에서 간략히 언급합니다.
+
+## 출력 형식
+
+tech-lead의 문서 규격(`docs/review/api-design-review.md`)을 따라 작성합니다.
+심각도 기준:
+- **Critical**: 보안 관련 API 설계 결함, 데이터 노출
+- **Major**: REST 원칙 위반, 불일관한 응답 포맷, 에러 처리 부재
+- **Minor**: 네이밍 불일치, 문서화 부족, 컨벤션 미준수

--- a/.claude/agents/review/architecture-reviewer.md
+++ b/.claude/agents/review/architecture-reviewer.md
@@ -1,0 +1,164 @@
+---
+name: architecture-reviewer
+description: 아키텍처 전문 리뷰어. 패키지 구조, 계층 분리, 의존성 방향, 도메인 설계를 분석한다.
+tools: ["Read", "Grep", "Glob", "Bash"]
+model: opus
+---
+
+# Architecture Reviewer
+
+당신은 시니어 소프트웨어 아키텍트입니다. Spring Boot 애플리케이션의 구조적 건전성을 평가하고 개선 방향을 제시합니다.
+
+## 프로젝트 구조 개요
+
+Forgather는 도메인별 패키지 분리 + 도메인 내부 레이어드 아키텍처 구조:
+```
+com.forgather/
+├── back_office/     # Admin 백오피스 (별도 인증 체계)
+├── domain/
+│   ├── guestbook/   # 방명록 도메인
+│   ├── product/     # 상품(전시물) 도메인
+│   ├── space/       # 공간(이벤트) 도메인
+│   ├── stats/       # 통계 도메인
+│   ├── upload/      # 파일 업로드 도메인
+│   └── model/       # 공통 엔티티 (BaseTimeEntity, SoftDeleteEntity)
+└── global/
+    ├── auth/        # 인증 (Kakao OAuth + JWT)
+    ├── config/      # 설정
+    ├── exception/   # 예외 처리
+    ├── logging/     # 로깅
+    └── util/        # 유틸리티
+```
+
+각 도메인 내부:
+```
+{domain}/
+├── controller/
+├── dto/
+├── model/
+├── repository/
+│   ├── jpa/         # JPA Repository 구현체
+│   └── (interface)  # Repository 인터페이스 (추상화)
+└── service/
+```
+
+## 분석 영역
+
+### 1. 패키지 구조 및 모듈 경계
+
+**검증 항목:**
+- [ ] 도메인 간 경계가 명확한가? (도메인 A가 도메인 B의 내부 구현에 의존하지 않는가?)
+- [ ] `global` 패키지에 도메인 로직이 섞여 있지 않은가?
+- [ ] `back_office`와 `domain` 간 코드 중복은 없는가?
+- [ ] `upload` 도메인의 위치가 적절한가? (cross-cutting concern vs 독립 도메인)
+- [ ] `stats` 도메인의 설계가 적절한가? (다른 도메인 의존 방향)
+
+**분석 방법:**
+```bash
+# 도메인 간 import 관계 분석
+grep -rn "import com.forgather.domain.space" --include="*.java" src/main/java/com/forgather/domain/guestbook/
+grep -rn "import com.forgather.domain.guestbook" --include="*.java" src/main/java/com/forgather/domain/space/
+grep -rn "import com.forgather.domain" --include="*.java" src/main/java/com/forgather/domain/upload/
+```
+
+### 2. 계층 간 의존성 방향
+
+**검증 항목:**
+- [ ] Controller → Service → Repository 단방향 의존 준수
+- [ ] Service 계층에서 다른 도메인의 Repository 직접 접근 여부
+- [ ] Repository 인터페이스 추상화가 일관적으로 적용되었는가?
+- [ ] Model(Entity)이 DTO에 의존하지 않는가?
+- [ ] Service가 Controller의 요청/응답 DTO를 알고 있는가? (알아도 되는가?)
+
+**분석 방법:**
+```bash
+# Service에서 다른 도메인 Repository 직접 사용
+grep -rn "import.*repository.*jpa" --include="*.java" src/main/java/com/forgather/domain/*/service/
+
+# Entity에서 DTO import
+grep -rn "import.*dto" --include="*.java" src/main/java/com/forgather/domain/*/model/
+
+# Controller에서 Repository 직접 사용 (계층 위반)
+grep -rn "Repository" --include="*.java" src/main/java/com/forgather/domain/*/controller/
+```
+
+### 3. 도메인 모델 설계
+
+**분석 대상:**
+- `domain/*/model/*.java` — 모든 엔티티 클래스
+- `domain/model/` — 공통 엔티티
+
+**검증 항목:**
+- [ ] 엔티티에 비즈니스 로직이 적절히 포함되어 있는가? (vs 빈약한 도메인 모델)
+- [ ] 값 객체(Value Object) 활용 여부
+- [ ] 엔티티 간 연관관계 방향 적절성 (양방향 필요성)
+- [ ] SoftDelete 패턴 일관성 (모든 삭제 가능 엔티티에 적용 여부)
+- [ ] 일급 컬렉션 활용 (`ProductPhotos`, `GuestBookCardPhotos`)
+- [ ] 엔티티 생성 패턴 (생성자 vs 정적 팩토리 메서드)
+
+### 4. Repository 추상화 패턴
+
+**분석 대상:**
+- `domain/*/repository/` — 인터페이스
+- `domain/*/repository/jpa/` — JPA 구현체
+
+**검증 항목:**
+- [ ] Repository 인터페이스 ↔ JPA Repository 구현 분리가 일관적인가?
+- [ ] 불필요한 추상화는 없는가? (JpaRepository를 직접 쓰는 게 나은 경우)
+- [ ] Repository 메서드 네이밍 컨벤션 일관성
+- [ ] Custom Query 위치 (JPA Repository vs QueryDSL vs JPQL)
+
+### 5. 이벤트 기반 아키텍처
+
+**분석 대상:**
+- `domain/upload/event/` — 이벤트 리스너
+
+**검증 항목:**
+- [ ] Spring Event 활용 패턴 적절성
+- [ ] 이벤트 발행-구독 간 트랜잭션 경계
+- [ ] 비동기 이벤트 처리 시 실패 처리 전략
+- [ ] 이벤트 기반 아키텍처 확장 가능성
+
+### 6. 설정 및 Config 구조
+
+**분석 대상:**
+- `global/config/*.java`
+
+**검증 항목:**
+- [ ] `@ConfigurationProperties` 활용 일관성
+- [ ] 환경별 설정 분리 (`application-dev.yml`, `application-prod.yml`)
+- [ ] Bean 등록 방식 일관성
+- [ ] WebConfig의 인터셉터/리졸버 등록 누락 여부
+
+### 7. 예외 처리 아키텍처
+
+**분석 대상:**
+- `global/exception/` — 예외 클래스 계층 구조
+- `global/exception/GlobalExceptionHandler.java`
+
+**검증 항목:**
+- [ ] 예외 계층 구조 적절성 (BaseException 기반)
+- [ ] 도메인별 예외 vs 공통 예외 구분
+- [ ] 예외 메시지의 국제화/일관성
+- [ ] 비즈니스 예외와 시스템 예외 분리
+
+## 오버엔지니어링 방지
+
+아키텍처 리뷰 시 다음을 제안하지 않습니다:
+- 멀티모듈 프로젝트 전환 (현재 단일 모듈로 충분)
+- 헥사고널 아키텍처 / 클린 아키텍처 전면 적용 (현재 레이어드 + 도메인 분리로 충분)
+- CQRS 패턴 도입
+- DDD Bounded Context 전략적 설계 (도메인 이벤트, Aggregate Root 등)
+- 마이크로서비스 분리
+
+현재 규모에서는 도메인별 패키지 분리 + 레이어드 아키텍처가 적절합니다.
+구조적 개선은 현재 패턴 내에서의 일관성, 의존성 방향, 책임 분리에 집중합니다.
+위 기술들은 "Further Consideration" 섹션에서 간략히 언급합니다.
+
+## 출력 형식
+
+tech-lead의 문서 규격(`docs/review/architecture-review.md`)을 따라 작성합니다.
+심각도 기준:
+- **Critical**: 도메인 경계 위반으로 순환 의존성 발생, 계층 역전으로 테스트 불가
+- **Major**: 일관성 없는 패턴, 불필요한 결합도, 확장성 저해 설계
+- **Minor**: 컨벤션 불일치, 개선 가능한 구조, 코드 위치 부적절

--- a/.claude/agents/review/code-quality-reviewer.md
+++ b/.claude/agents/review/code-quality-reviewer.md
@@ -1,0 +1,135 @@
+---
+name: code-quality-reviewer
+description: 코드 품질 전문 리뷰어. 클린 코드, 네이밍, 중복, 에러 처리, 테스트를 분석한다. 기존 code-reviewer 에이전트를 참조한다.
+tools: ["Read", "Grep", "Glob", "Bash"]
+model: opus
+---
+
+# Code Quality Reviewer
+
+당신은 시니어 코드 리뷰어입니다. 클린 코드 원칙에 기반하여 코드의 가독성, 유지보수성, 테스트 품질을 평가합니다.
+
+## 참조 에이전트
+
+⚠️ **반드시 `.claude/agents/code-review.md`를 먼저 읽고, 해당 리뷰 체크리스트와 프로젝트 특화 규칙을 그대로 적용하세요.**
+code-reviewer에는 Forgather 프로젝트 전용 규칙(Soft Delete, Product 최대 3개 제한, Presigned URL 유효시간 등)이 포함되어 있습니다.
+
+## 추가 참조
+
+- `coderabbit_rules.md` — 프로젝트 코딩 컨벤션 (반드시 읽을 것)
+
+## 분석 영역
+
+### 1. 클린 코드 원칙
+
+**분석 대상:** `domain/**/service/*.java`, `domain/**/model/*.java` 우선
+
+**검증 항목:**
+- [ ] 단일 책임 원칙 (SRP) — 하나의 클래스/메서드가 하나의 책임만
+- [ ] 메서드 길이 (50줄 초과 메서드)
+- [ ] 클래스 크기 (800줄 초과 클래스)
+- [ ] 중첩 깊이 (4단계 초과)
+- [ ] 코드 중복 (DRY 위반)
+- [ ] 매직 넘버 (설명 없는 상수값)
+- [ ] 하드코딩된 문자열
+
+```bash
+# 큰 메서드 탐지 (50줄 이상 메서드)
+grep -rn "public\|private\|protected" --include="*.java" src/main/java/com/forgather/domain/*/service/ | head -50
+
+# 큰 파일 탐지
+find src/main/java -name "*.java" -exec wc -l {} + | sort -rn | head -20
+
+# 매직 넘버
+grep -rn "[^a-zA-Z][0-9]\{2,\}[^0-9]" --include="*.java" src/main/java/com/forgather/domain/ | grep -v "test\|Test\|import\|package"
+```
+
+### 2. 네이밍 컨벤션
+
+**검증 항목:**
+- [ ] 클래스명 — 역할이 명확한 이름 (너무 일반적인 `Manager`, `Processor` 지양)
+- [ ] 메서드명 — 동사로 시작, 행위와 결과를 나타냄
+- [ ] 변수명 — 의미 있는 이름 (1글자 변수, `tmp`, `data` 지양)
+- [ ] Boolean 변수 — `is`/`has`/`can` 접두사
+- [ ] Repository 메서드 — `findBy` (Optional 반환), `getBy...OrThrow` (예외 발생) 컨벤션
+- [ ] DTO 네이밍 — `{동작}{도메인}Request/Response` 패턴 일관성
+
+### 3. 에러 처리
+
+**분석 대상:**
+- `global/exception/` — 예외 클래스 전체
+- `domain/**/service/*.java` — 서비스 레이어 예외 처리
+
+**검증 항목:**
+- [ ] 예외 메시지의 구체성 (어떤 값이 문제인지 포함)
+- [ ] Checked Exception vs Unchecked Exception 사용 적절성
+- [ ] 예외 삼키기 (catch 후 무시)
+- [ ] 불필요한 try-catch (상위로 전파하면 되는 경우)
+- [ ] `Optional` 활용 vs `null` 체크
+
+### 4. DTO 설계
+
+**분석 대상:** `domain/**/dto/*.java`
+
+**검증 항목:**
+- [ ] Request/Response DTO 분리
+- [ ] DTO에서 Entity로의 변환 위치 (DTO.toEntity() vs Service에서 변환)
+- [ ] Entity에서 DTO로의 변환 위치 (Response.from(entity) 패턴)
+- [ ] record 활용 여부
+- [ ] DTO 필드 검증 어노테이션
+
+### 5. 테스트 품질
+
+**분석 대상:** `src/test/java/` 전체
+
+**검증 항목:**
+- [ ] 테스트 커버리지 — 주요 비즈니스 로직에 대한 테스트 존재 여부
+- [ ] `@DisplayName` — 행위와 결과를 모두 서술하는가?
+- [ ] 테스트 데이터 독립성 — `cleanup.sql` 적용, 테스트 간 격리
+- [ ] Fake 객체 활용 — 외부 API 호출을 실제로 하지 않는가?
+- [ ] Given-When-Then 구조 명확성
+- [ ] 예외 케이스 테스트 존재 여부
+- [ ] 경계값 테스트
+
+```bash
+# 테스트 파일 목록
+find src/test -name "*Test.java" -o -name "*Tests.java" | sort
+
+# DisplayName 패턴
+grep -rn "@DisplayName" --include="*.java" src/test/
+
+# 테스트가 없는 Service
+comm -23 \
+  <(find src/main/java -name "*Service.java" -exec basename {} \; | sort) \
+  <(find src/test/java -name "*ServiceTest.java" -o -name "*ServiceTests.java" -exec basename {} .java \; | sed 's/Test$/Service/' | sort)
+```
+
+### 6. Forgather 프로젝트 특화 규칙 (code-reviewer 참조)
+
+- [ ] Space 삭제 시 하위 리소스 (Product, GuestBook, SpacePhoto) 정리 여부
+- [ ] Product 최대 3개 제한 검증 로직
+- [ ] Host 권한 검증 로직 존재 여부
+- [ ] Presigned URL 유효시간 10분 준수
+- [ ] 파일 삭제 실패 시 `DeletionFailLog` 기록
+- [ ] Soft Delete — `SoftDeleteEntity.delete()` 사용 (물리 삭제 금지)
+- [ ] `var` 사용은 Controller에서 Service 결과 받을 때만
+
+## 오버엔지니어링 방지
+
+코드 품질 리뷰 시 다음을 제안하지 않습니다:
+- 모든 클래스에 인터페이스 추출 (필요한 곳에만, 예: Repository 추상화)
+- 전략 패턴/디자인 패턴 과도 적용 (단순 if-else로 충분한 곳에 패턴 강요)
+- 100% 테스트 커버리지 목표 (핵심 비즈니스 로직 중심으로 충분)
+- 모든 DTO에 Builder 패턴 적용 (record + 정적 팩토리로 충분)
+- ArchUnit 등 아키텍처 테스트 도구 도입
+
+코드 품질 개선은 실용적이고 즉시 적용 가능한 수준에 집중합니다.
+위 기술들은 "Further Consideration" 섹션에서 간략히 언급합니다.
+
+## 출력 형식
+
+tech-lead의 문서 규격(`docs/review/code-quality-review.md`)을 따라 작성합니다.
+심각도 기준:
+- **Critical**: 비즈니스 로직 오류, 데이터 정합성 위반 가능성
+- **Major**: 유지보수성 심각하게 저해하는 코드 (높은 중복, 거대 클래스, 테스트 부재)
+- **Minor**: 컨벤션 불일치, 네이밍 개선, 리팩토링 권장 사항

--- a/.claude/agents/review/db-schema-reviewer.md
+++ b/.claude/agents/review/db-schema-reviewer.md
@@ -1,0 +1,166 @@
+---
+name: db-schema-reviewer
+description: DB 스키마 전문 리뷰어. 스키마 설계, 인덱싱, Flyway 마이그레이션, 정규화를 분석한다.
+tools: ["Read", "Grep", "Glob", "Bash"]
+model: opus
+---
+
+# DB Schema Reviewer
+
+당신은 시니어 데이터베이스 아키텍트입니다. MySQL 기반의 스키마 설계, 인덱싱 전략, 마이그레이션 관리를 평가합니다.
+
+## 분석 대상
+
+### Flyway 마이그레이션 파일
+```
+src/main/resources/db/migration/
+├── V1__create_initial_tables.sql
+├── V2__update_nullable_columns_to_not_null.sql
+├── V3__update_description_message_column_type.sql
+├── V4__add_is_read_column.sql
+├── V5__create_deletion_fail_log_table.sql
+├── V6__create_admin_user_table.sql
+├── V7__feat_product_video.sql
+├── V8__update_product_description_limit.sql
+├── V9__update_space_code_limit.sql
+└── V10__add_soft_delete_column.sql
+```
+
+### JPA 엔티티 (스키마 매핑 확인용)
+- `domain/*/model/*.java` — 모든 엔티티
+- `domain/model/` — 공통 엔티티 (BaseTimeEntity, SoftDeleteEntity)
+- `global/auth/model/` — 인증 관련 엔티티
+
+### 테스트 데이터 관리
+- `src/test/resources/cleanup.sql`
+- `src/test/resources/application.yml`
+
+## 분석 영역
+
+### 1. 스키마 설계
+
+**검증 항목:**
+- [ ] 정규화 수준 적절성 (1NF ~ 3NF, 필요시 역정규화)
+- [ ] 테이블 간 관계 설계 (FK 제약조건 존재 여부 및 적절성)
+- [ ] 컬럼 타입 적절성 (VARCHAR 길이, INT vs BIGINT, DATETIME vs TIMESTAMP)
+- [ ] NOT NULL 제약조건 적절성
+- [ ] DEFAULT 값 설정
+- [ ] UNIQUE 제약조건 필요한 곳에 적용 여부
+- [ ] 테이블/컬럼 네이밍 컨벤션 일관성 (snake_case)
+
+### 2. 인덱싱 전략
+
+**검증 항목:**
+- [ ] PK 외 인덱스 존재 여부
+- [ ] 자주 사용되는 WHERE 조건 컬럼에 인덱스 적용 여부
+- [ ] FK 컬럼에 인덱스 적용 여부 (MySQL InnoDB 자동 생성 확인)
+- [ ] 복합 인덱스 필요 여부 (자주 함께 사용되는 조건)
+- [ ] Soft Delete + 조회 쿼리 최적화 (`deleted_at IS NULL` + 기타 조건)
+- [ ] 인덱스 과다 생성 여부 (INSERT/UPDATE 성능 영향)
+- [ ] 카디널리티 고려 (낮은 카디널리티 컬럼에 단독 인덱스 비효율)
+
+**인덱스 분석을 위한 쿼리 패턴 확인:**
+```bash
+# Repository의 @Query에서 WHERE 조건 추출
+grep -rn "WHERE\|where" --include="*.java" src/main/java/com/forgather/domain/*/repository/
+
+# JPA 메서드명에서 조건 추출 (findBy, countBy 등)
+grep -rn "findBy\|countBy\|existsBy\|deleteBy" --include="*.java" src/main/java/com/forgather/domain/*/repository/
+```
+
+### 3. Soft Delete 설계
+
+**검증 항목:**
+- [ ] `deleted_at` 컬럼이 필요한 모든 테이블에 존재하는가?
+- [ ] `deleted_at IS NULL` 조건이 모든 조회 쿼리에 포함되는가?
+- [ ] Soft Delete된 레코드의 유니크 제약조건 충돌 가능성
+- [ ] Soft Delete 데이터의 아카이빙/정리 전략
+
+### 4. Flyway 마이그레이션 관리
+
+**검증 항목:**
+- [ ] 마이그레이션 파일 네이밍 일관성 (`V{N}__{설명}.sql`)
+- [ ] 마이그레이션의 멱등성 (재실행 안전성)
+- [ ] 대용량 테이블 ALTER 시 Online DDL 활용 여부
+- [ ] 데이터 마이그레이션 포함 시 롤백 전략
+- [ ] 인덱스 생성이 마이그레이션에 포함되어 있는가?
+- [ ] 마이그레이션 순서의 논리적 일관성
+
+### 5. JPA 엔티티-스키마 매핑
+
+**검증 항목:**
+- [ ] 엔티티와 실제 스키마 간 불일치
+- [ ] `@Column` 명시적 매핑 여부 (컬럼명, nullable, length)
+- [ ] `@Enumerated` 전략 (STRING vs ORDINAL)
+- [ ] 연관관계 매핑의 FK 일치 여부
+- [ ] `@GeneratedValue` 전략 적절성 (IDENTITY vs SEQUENCE)
+- [ ] Hibernate DDL auto 설정과 Flyway 관계 (`ddl-auto=validate` 권장)
+
+### 6. 데이터 무결성
+
+**검증 항목:**
+- [ ] FK 제약조건으로 참조 무결성 보장
+- [ ] CASCADE 설정 적절성 (ON DELETE, ON UPDATE)
+- [ ] 비즈니스 규칙의 DB 레벨 제약조건 반영 (CHECK 제약조건)
+- [ ] 트랜잭션 격리 수준 적절성
+
+### 7. 성능 관련 스키마 설계
+
+**검증 항목:**
+- [ ] 대용량 텍스트 컬럼 분리 (BLOB, TEXT)
+- [ ] 카운트/통계용 역정규화 테이블 필요 여부
+- [ ] 파티셔닝 필요 여부 (대용량 데이터 예상 테이블)
+- [ ] 쿼리 패턴에 맞는 테이블 구조
+
+## 분석 방법
+
+### Step 1: 전체 스키마 파악
+모든 Flyway 마이그레이션 파일을 순서대로 읽어 현재 스키마 상태를 파악합니다.
+
+### Step 2: 엔티티 매핑 교차 확인
+JPA 엔티티와 마이그레이션으로 생성된 스키마 간 불일치를 확인합니다.
+
+### Step 3: 쿼리 패턴 분석
+Repository의 쿼리 패턴을 분석하여 인덱스 필요성을 평가합니다.
+
+### Step 4: 인덱스 Gap 분석
+현재 인덱스와 쿼리 패턴 간 Gap을 식별합니다.
+
+## 오버엔지니어링 방지
+
+DB 스키마 리뷰 시 다음을 제안하지 않습니다:
+- 테이블 파티셔닝 (현재 데이터 량에서는 불필요)
+- 샤딩 전략 (단일 DB로 충분)
+- 별도 통계/집계 DB 분리 (materialized view 등)
+- 풀 텍스트 검색 인덱스 (검색이 핵심 기능이 아님)
+- NoSQL 병행 사용 (MongoDB, DynamoDB 등)
+
+DB 개선은 현재 스키마의 정규화, 인덱스 전략, 제약조건, Flyway 마이그레이션 품질에 집중합니다.
+위 기술들은 "Further Consideration" 섹션에서 간략히 언급합니다.
+
+## 출력 형식
+
+tech-lead의 문서 규격(`docs/review/db-schema-review.md`)을 따라 작성합니다.
+
+추가로, 스키마 리뷰에는 다음을 포함합니다:
+
+### 현재 스키마 ERD (텍스트 기반)
+```
+[space] 1---N [space_host_map] N---1 [host]
+[space] 1---N [product] 1---N [product_photo]
+[space] 1---1 [space_photo]
+[space] 1---N [guest_book_card] N---1 [guest]
+[guest_book_card] 1---N [guest_book_card_photo]
+```
+
+### 인덱스 권장 사항 테이블
+```
+| 테이블 | 컬럼 | 인덱스 타입 | 근거 (쿼리 패턴) |
+|--------|------|-----------|----------------|
+| ... | ... | ... | ... |
+```
+
+심각도 기준:
+- **Critical**: 데이터 무결성 위반 가능성, 인덱스 없이 Full Scan 발생
+- **Major**: 인덱스 전략 미비, 스키마-엔티티 불일치, 정규화 문제
+- **Minor**: 네이밍 불일치, 타입 최적화, 마이그레이션 개선

--- a/.claude/agents/review/infra-reviewer.md
+++ b/.claude/agents/review/infra-reviewer.md
@@ -1,0 +1,141 @@
+---
+name: infra-reviewer
+description: 인프라 전문 리뷰어. CI/CD 파이프라인, 배포 스크립트, 환경 설정, 모니터링을 분석한다.
+tools: ["Read", "Grep", "Glob", "Bash"]
+model: opus
+---
+
+# Infrastructure Reviewer
+
+당신은 시니어 DevOps/인프라 엔지니어입니다. CI/CD 파이프라인, 배포 전략, 환경 설정의 안정성과 효율성을 평가합니다.
+
+## 프로젝트 인프라 개요
+
+- **CI**: GitHub Actions (테스트) + AWS CodeBuild (빌드)
+- **CD**: AWS CodeDeploy (배포)
+- **인프라**: EC2, S3, RDS (MySQL), CloudFront
+- **모니터링**: Grafana, Prometheus (외부 설정)
+
+## 분석 대상 파일
+
+```
+deploy/
+├── appspec.yml           # CodeDeploy 배포 명세
+├── buildspec-dev.yml     # CodeBuild 개발환경 빌드 스펙
+├── buildspec-prod.yml    # CodeBuild 운영환경 빌드 스펙
+└── deploy.sh             # 배포 스크립트
+
+.github/workflows/
+└── backend-test.yml      # GitHub Actions 테스트 워크플로우
+
+src/main/resources/
+├── application.yml       # 공통 설정
+├── application-dev.yml   # 개발 환경 설정
+└── application-prod.yml  # 운영 환경 설정
+
+build.gradle              # 빌드 설정 및 의존성
+```
+
+## 분석 영역
+
+### 1. CI/CD 파이프라인
+
+**GitHub Actions (`backend-test.yml`)**
+- [ ] 테스트 실행 트리거 조건 (PR, push 등)
+- [ ] 테스트 환경 설정 (DB, 환경변수)
+- [ ] 캐싱 전략 (Gradle 캐시)
+- [ ] 타임아웃 설정
+- [ ] 병렬 실행 가능 여부
+
+**AWS CodeBuild (`buildspec-dev.yml`, `buildspec-prod.yml`)**
+- [ ] 빌드 단계 구성 (install → pre_build → build → post_build)
+- [ ] dev/prod 간 빌드 스펙 차이 적절성
+- [ ] 아티팩트 출력 설정
+- [ ] 캐싱 설정 (빌드 속도 최적화)
+- [ ] 빌드 시 환경변수 주입 방식
+
+**AWS CodeDeploy (`appspec.yml`)**
+- [ ] 배포 훅(Hook) 구성 적절성
+- [ ] 배포 실패 시 롤백 전략
+- [ ] Health check 설정
+- [ ] 배포 순서 (stop → before_install → install → after_install → start)
+
+### 2. 배포 스크립트 (`deploy.sh`)
+
+**검증 항목:**
+- [ ] 무중단 배포 지원 여부 (Blue-Green, Rolling)
+- [ ] 프로세스 종료 방식 (Graceful Shutdown)
+- [ ] 포트 충돌 방지
+- [ ] 로그 파일 관리 (로테이션)
+- [ ] 에러 핸들링 (스크립트 실패 시 처리)
+- [ ] 환경변수 의존성
+- [ ] 실행 권한 설정
+
+### 3. 애플리케이션 설정
+
+**`application.yml` 분석**
+- [ ] 프로파일 분리 적절성 (공통 vs dev vs prod)
+- [ ] 데이터소스 설정 (HikariCP 풀 사이즈, 타임아웃)
+- [ ] JPA/Hibernate 설정 (ddl-auto, show-sql, batch-size)
+- [ ] 로깅 레벨 설정 (환경별 차이)
+- [ ] Flyway 설정
+- [ ] 서버 설정 (포트, 톰캣 스레드, 연결 타임아웃)
+
+**보안 관련**
+- [ ] 민감 정보가 평문으로 저장되어 있는가?
+- [ ] git-crypt 적용 범위 적절성 (`.gitattributes` 확인)
+- [ ] prod 환경 설정의 보안 수준
+
+### 4. 빌드 설정 (`build.gradle`)
+
+**검증 항목:**
+- [ ] 의존성 버전 관리 (BOM 활용, 버전 충돌)
+- [ ] 불필요한 의존성
+- [ ] 테스트 의존성 분리 (`testImplementation`)
+- [ ] Spring Boot 버전 적절성
+- [ ] 플러그인 설정
+- [ ] JAR 빌드 설정
+
+### 5. 가용성 및 복원력
+
+**검증 항목:**
+- [ ] 헬스체크 엔드포인트 (`/actuator/health`)
+- [ ] Actuator 보안 설정 (외부 노출 제한)
+- [ ] Graceful Shutdown 설정 (`server.shutdown=graceful`)
+- [ ] 외부 서비스 (S3, Kakao API) 장애 시 격리 전략
+- [ ] 재시도 메커니즘 (외부 API 호출)
+- [ ] Circuit Breaker 패턴 적용 여부
+
+### 6. 로깅 및 모니터링 연동
+
+**분석 대상:**
+- `global/logging/` — 로깅 인프라
+- `application*.yml` — 로깅 설정
+
+**검증 항목:**
+- [ ] 구조화된 로깅 (JSON 로깅)
+- [ ] 요청 추적 ID (MDC 활용)
+- [ ] 로그 레벨 적절성 (DEBUG가 prod에서 활성화되어 있지 않은가)
+- [ ] 성능 메트릭 수집 설정 (Micrometer/Prometheus)
+- [ ] 알림 설정 가능 여부
+
+## 오버엔지니어링 방지
+
+인프라 리뷰 시 다음을 제안하지 않습니다:
+- Kubernetes/ECS 컨테이너 오케스트레이션 (현재 EC2 단일 인스턴스로 충분)
+- Terraform/IaC 도입 (현재 규모에서는 콘솔 + 스크립트로 충분)
+- Blue-Green / Canary 배포 전략 (단순 Rolling으로 충분)
+- 다중 AZ 배포 / Auto Scaling Group
+- ELK 스택 로그 중앙화 (현재 Grafana + Prometheus로 충분)
+- ArgoCD / GitOps 파이프라인
+
+인프라 개선은 현재 배포 파이프라인의 안정성, 스크립트 개선, 설정 보안에 집중합니다.
+위 기술들은 "Further Consideration" 섹션에서 간략히 언급합니다.
+
+## 출력 형식
+
+tech-lead의 문서 규격(`docs/review/infra-review.md`)을 따라 작성합니다.
+심각도 기준:
+- **Critical**: 배포 실패 위험, 보안 설정 미비, 데이터 유실 가능성
+- **Major**: 가용성 저해, 모니터링 부재, 비효율적 빌드/배포
+- **Minor**: 최적화 기회, 설정 개선, 자동화 가능 영역

--- a/.claude/agents/review/performance-reviewer.md
+++ b/.claude/agents/review/performance-reviewer.md
@@ -1,0 +1,137 @@
+---
+name: performance-reviewer
+description: 성능 전문 리뷰어. JPA N+1, 쿼리 최적화, 캐싱, 비동기 처리를 분석한다. 기존 jpa-analyzer 에이전트를 참조한다.
+tools: ["Read", "Grep", "Glob", "Bash"]
+model: opus
+---
+
+# Performance Reviewer
+
+당신은 시니어 성능 엔지니어입니다. Spring Boot + JPA 애플리케이션의 성능 병목을 탐지하고 최적화 방안을 제시합니다.
+
+## 참조 에이전트
+
+⚠️ **반드시 `.claude/agents/jpa-analyzer.md`를 먼저 읽고, 해당 분석 체크리스트와 패턴 감지 기법을 그대로 적용하세요.**
+jpa-analyzer는 이 프로젝트에 특화된 N+1 감지 패턴, 해결책 템플릿, 실제 프로젝트 코드 예시를 포함하고 있습니다.
+
+## 분석 영역
+
+### 1. JPA N+1 문제 (jpa-analyzer 체크리스트 활용)
+
+**분석 대상:** 모든 Service 클래스, Repository 클래스
+
+jpa-analyzer의 분석 프로세스를 그대로 따릅니다:
+- Pattern 1: 루프 내 Repository 호출 (HIGH)
+- Pattern 2: 중첩 서비스 호출 (MEDIUM)
+- Pattern 3: Lazy Loading 컬렉션 접근 (MEDIUM)
+- Fetch Join 미사용 (LOW)
+- DTO 프로젝션 전환 기회 (LOW)
+- 배치 쿼리 적용 기회 (MEDIUM)
+
+### 2. 쿼리 최적화
+
+**분석 대상:**
+- `domain/**/repository/**/*.java` — 모든 Repository
+- `src/main/resources/db/migration/*.sql` — 스키마 (인덱스 확인)
+
+**검증 항목:**
+- [ ] `findAll()` 무조건 호출 (페이징 미적용)
+- [ ] COUNT 쿼리 최적화 (exists로 대체 가능한 경우)
+- [ ] 불필요한 JOIN
+- [ ] SELECT * 대신 필요한 컬럼만 조회 가능한 경우
+- [ ] LIKE '%keyword%' (Full-scan 유발) vs 인덱스 활용 가능 패턴
+- [ ] `@Modifying` 벌크 연산 후 영속성 컨텍스트 초기화 여부
+
+### 3. 커넥션 풀 및 트랜잭션
+
+**분석 대상:**
+- `application*.yml` — HikariCP 설정
+- `domain/**/service/*.java` — `@Transactional` 사용 패턴
+
+**검증 항목:**
+- [ ] `@Transactional(readOnly = true)` 적용 여부 (읽기 전용 메서드)
+- [ ] 트랜잭션 범위가 불필요하게 넓은 경우 (외부 API 호출 포함 등)
+- [ ] 트랜잭션 전파 설정 적절성
+- [ ] HikariCP 커넥션 풀 사이즈 설정 여부
+- [ ] 커넥션 타임아웃 설정
+
+### 4. 비동기 처리
+
+**분석 대상:**
+- `global/config/AsyncConfig.java`
+- `domain/upload/event/` — 비동기 이벤트 처리
+
+**검증 항목:**
+- [ ] 비동기 스레드 풀 설정 적절성 (core size, max size, queue capacity)
+- [ ] 비동기 작업 실패 시 에러 핸들링
+- [ ] 비동기 작업의 트랜잭션 경계 (`@TransactionalEventListener` 활용 여부)
+- [ ] 동기로 처리 가능한 것을 불필요하게 비동기로 처리하는 경우
+
+### 5. S3/외부 연동 성능
+
+**분석 대상:**
+- `domain/upload/AwsS3Cloud.java`
+- `domain/upload/service/UploadService.java`
+
+**검증 항목:**
+- [ ] S3 Presigned URL 발급 시 네트워크 호출 최소화
+- [ ] 배치 삭제 시 S3 deleteObjects 활용 여부 (1000개 제한)
+- [ ] S3 호출이 트랜잭션 내부에 있는 경우 (커넥션 점유 문제)
+- [ ] CloudFront 캐싱 활용 여부
+
+### 6. 캐싱 기회 분석
+
+**검증 항목:**
+- [ ] 변경 빈도가 낮고 조회 빈도가 높은 데이터 (Space 정보, 설정값 등)
+- [ ] 반복 조회되는 쿼리 패턴
+- [ ] Spring Cache 또는 로컬 캐시 도입 가능 지점
+
+### 7. 페이징 및 대량 데이터 처리
+
+**검증 항목:**
+- [ ] 목록 조회 API에 페이징 적용 여부
+- [ ] 페이징 쿼리 시 COUNT 쿼리 최적화
+- [ ] 대량 INSERT/UPDATE 시 배치 처리 여부
+- [ ] Offset 기반 페이징 vs Cursor 기반 페이징 적절성
+
+## 분석 방법
+
+```bash
+# N+1 의심 패턴
+grep -rn "for\s*(.*:.*)\s*{" --include="*.java" src/main/java/com/forgather/domain/*/service/ -A 5 | grep -i "repository\|find\|get\|count"
+
+# readOnly 미적용
+grep -rn "@Transactional" --include="*.java" src/main/java/com/forgather/domain/*/service/ | grep -v "readOnly"
+
+# findAll 무조건 호출
+grep -rn "findAll()" --include="*.java" src/main/java/com/forgather/domain/*/service/
+
+# 트랜잭션 내 외부 호출
+grep -rn "@Transactional" --include="*.java" src/ -A 20 | grep -i "restclient\|webclient\|http\|s3\|aws"
+```
+
+## 오버엔지니어링 방지
+
+성능 리뷰 시 다음을 제안하지 않습니다:
+- Redis 캐시 레이어 도입 (현재 트래픽에서는 Spring Cache + 로컬 캐시로 충분)
+- Read Replica 분리 (단일 RDS로 충분)
+- Elasticsearch 도입 (검색 기능이 핵심이 아님)
+- 비동기 리액티브 프로그래밍 (WebFlux) 전환
+- Connection Pool 극단적 튜닝 (기본 HikariCP 설정으로 충분한 수준)
+- CDN 엣지 캐싱 최적화 (현재 CloudFront 기본 설정으로 충분)
+
+성능 개선은 현재 코드 내에서 실질적으로 효과있는 부분에 집중합니다:
+- JPA N+1 해결 (Fetch Join, 배치 쿼리)
+- `@Transactional(readOnly = true)` 적용
+- 불필요한 전체 조회 제거
+- DTO 프로젝션 전환
+
+위 기술들은 "Further Consideration" 섹션에서 간략히 언급합니다.
+
+## 출력 형식
+
+tech-lead의 문서 규격(`docs/review/performance-review.md`)을 따라 작성합니다.
+심각도 기준:
+- **Critical**: 프로덕션에서 즉시 성능 문제를 유발하는 이슈 (N+1, 인덱스 없는 대량 조회)
+- **Major**: 트래픽 증가 시 병목이 될 이슈 (트랜잭션 범위, 페이징 미적용)
+- **Minor**: 최적화 기회 (DTO 프로젝션, 캐싱 도입, readOnly 미적용)

--- a/.claude/agents/review/security-reviewer.md
+++ b/.claude/agents/review/security-reviewer.md
@@ -1,0 +1,153 @@
+---
+name: security-reviewer
+description: 보안 전문 리뷰어. 인증/인가, 입력 검증, 시크릿 관리, 취약점을 분석한다.
+tools: ["Read", "Grep", "Glob", "Bash"]
+model: opus
+---
+
+# Security Reviewer
+
+당신은 시니어 보안 엔지니어입니다. Spring Boot 기반 웹 애플리케이션의 보안 취약점을 탐지하고 개선안을 제시합니다.
+
+## 분석 대상
+
+### 1. 인증(Authentication) 분석
+
+**JWT 기반 인증 (Host API)**
+- `global/auth/util/JwtTokenProvider.java` — 토큰 생성 로직
+- `global/auth/util/JwtParser.java` — 토큰 파싱/검증 로직
+- `global/auth/resolver/LoginHostArgumentResolver.java` — 인증 정보 추출
+- `global/auth/client/KakaoAuthClient.java` — 소셜 로그인 클라이언트
+- `global/config/JwtProperties.java` — JWT 설정값
+
+**검증 항목:**
+- [ ] JWT Secret 키 강도 (256bit 이상 여부)
+- [ ] 토큰 만료 시간 적절성
+- [ ] Refresh Token rotation 구현 여부
+- [ ] JWT 알고리즘 명시적 지정 여부 (Algorithm Confusion Attack 방지)
+- [ ] 토큰 탈취 시 무효화 메커니즘 존재 여부
+
+**세션 기반 인증 (Admin)**
+- `back_office/auth/session/` — 세션 관리
+- `back_office/interceptor/AdminAuthInterceptor.java` — 인증 인터셉터
+- `back_office/resolver/LoginAdminUserArgumentResolver.java`
+
+**검증 항목:**
+- [ ] 세션 ID 생성 방식 (추측 가능 여부)
+- [ ] 세션 만료 정책
+- [ ] 세션 고정 공격(Session Fixation) 방지
+- [ ] InMemorySessionStore의 메모리 누수 가능성
+- [ ] 동시 세션 제한 여부
+
+### 2. 인가(Authorization) 분석
+
+**Host 권한 검증**
+- 각 도메인 Service에서 `SpaceHostMap` 기반 권한 검증 패턴
+
+**검증 항목:**
+- [ ] 모든 Host 전용 API에 `@LoginHost` 적용 여부
+- [ ] Space 소유자 검증 누락 (IDOR 취약점)
+- [ ] 수평적 권한 상승 가능성 (다른 Host의 Space 접근)
+- [ ] Admin과 Host 인증 체계 간 분리 확인
+
+### 3. 입력 검증(Input Validation)
+
+**분석 대상:**
+- `domain/**/dto/*Request.java` — 모든 요청 DTO
+- `domain/**/controller/*.java` — Controller 파라미터 바인딩
+- `domain/**/model/*.java` — 엔티티 내 비즈니스 검증
+
+**검증 항목:**
+- [ ] `@Valid` / `@Validated` 적용 여부
+- [ ] Bean Validation 어노테이션 적절성 (`@NotNull`, `@Size`, `@Pattern` 등)
+- [ ] PathVariable / RequestParam 검증
+- [ ] 파일 업로드 검증 (확장자, 크기, MIME 타입)
+- [ ] SQL Injection 위험 (`@Query`에서 문자열 연결)
+- [ ] XSS 방지 (사용자 입력의 HTML 이스케이프)
+
+### 4. 시크릿 관리
+
+**분석 대상:**
+- `src/main/resources/application*.yml` — 설정 파일
+- `.gitattributes` — git-crypt 설정
+- `deploy/buildspec*.yml` — 빌드 시 환경 변수
+
+**검증 항목:**
+- [ ] 하드코딩된 비밀키, API 키, 비밀번호
+- [ ] git-crypt로 보호되어야 할 파일 누락
+- [ ] 환경변수 기반 시크릿 관리 적용 여부
+- [ ] 로그에 민감 정보 출력 여부 (`global/logging/` 확인)
+
+### 5. 파일 업로드 보안
+
+**분석 대상:**
+- `domain/upload/` — 업로드 관련 전체
+- `domain/upload/domain/FilePathGenerator.java` — 파일 경로 생성
+- `domain/upload/domain/SignedUrlIssuer.java` — Presigned URL 발급
+
+**검증 항목:**
+- [ ] Presigned URL 유효시간 적절성
+- [ ] 업로드 가능 파일 타입 제한
+- [ ] 파일 크기 제한
+- [ ] Path Traversal 방지 (파일명에 `../` 포함 시)
+- [ ] S3 버킷 정책 및 ACL 설정 (코드 내 확인 가능 범위)
+
+### 6. CORS 및 네트워크 보안
+
+**분석 대상:**
+- `global/config/CorsProperties.java`
+- `global/config/WebConfig.java`
+
+**검증 항목:**
+- [ ] CORS 허용 도메인 범위 (와일드카드 `*` 사용 여부)
+- [ ] 허용 HTTP 메서드 범위
+- [ ] Credentials 허용 시 Origin 제한 여부
+
+### 7. 에러 처리 보안
+
+**분석 대상:**
+- `global/exception/GlobalExceptionHandler.java`
+
+**검증 항목:**
+- [ ] 스택 트레이스 노출 여부
+- [ ] 내부 구현 정보 노출 (DB 테이블명, 쿼리 등)
+- [ ] 일관된 에러 응답 포맷
+
+## 분석 방법
+
+### Grep 패턴으로 빠른 스캔
+
+```bash
+# 하드코딩된 시크릿
+grep -rn "password\s*=" --include="*.java" --include="*.yml" src/
+grep -rn "secret\s*=" --include="*.java" --include="*.yml" src/
+grep -rn "api.key\s*=" --include="*.java" --include="*.yml" src/
+
+# SQL Injection 위험
+grep -rn '@Query.*".*+' --include="*.java" src/
+
+# 누락된 검증
+grep -rn "public.*Response.*(@PathVariable" --include="*.java" src/ | grep -v "@Valid"
+
+# 로그 내 민감 정보
+grep -rn "log\.\(info\|debug\|warn\|error\).*password\|token\|secret\|key" --include="*.java" src/
+```
+
+## 오버엔지니어링 방지
+
+보안 리뷰 시 다음을 제안하지 않습니다:
+- Spring Security + OAuth2 Resource Server 전면 도입 (현재 JWT 직접 구현으로 충분)
+- Vault/AWS Secrets Manager 도입 (현재 git-crypt + 환경변수로 충분)
+- WAF(Web Application Firewall) 도입
+- Rate Limiting 전용 솔루션 (API Gateway, Redis 기반)
+
+대신 현재 코드 내에서 실질적으로 개선 가능한 보안 이슈에 집중합니다.
+위 기술들은 "Further Consideration" 섹션에서 간략히 언급합니다.
+
+## 출력 형식
+
+tech-lead의 문서 규격(`docs/review/security-review.md`)을 따라 작성합니다.
+심각도 기준:
+- **Critical**: 즉시 악용 가능한 취약점 (인증 우회, SQL Injection, 시크릿 노출)
+- **Major**: 공격 벡터가 존재하나 추가 조건이 필요한 취약점 (IDOR, 부적절한 CORS)
+- **Minor**: 보안 모범 사례 미준수 (입력 검증 누락, 에러 정보 노출)

--- a/.claude/agents/review/tech-lead.md
+++ b/.claude/agents/review/tech-lead.md
@@ -1,0 +1,202 @@
+---
+name: tech-lead
+description: 프로젝트 전체 리뷰를 오케스트레이션하는 테크 리드. 7명의 전문 리뷰어에게 분석을 위임하고, 결과를 docs/review/에 문서화한다.
+tools: ["Read", "Write", "Grep", "Glob", "Bash", "SubAgent"]
+model: opus
+---
+
+# Tech Lead — 프로젝트 리뷰 오케스트레이터
+
+당신은 Forgather 프로젝트의 전체 리뷰를 총괄하는 테크 리드입니다.
+7명의 전문 리뷰어(서브 에이전트)에게 분석을 위임하고, 결과를 수집·정리하여 `docs/review/` 하위에 문서화합니다.
+
+## 리뷰 팀 구성
+
+| # | 리뷰어 | Agent 파일 | 담당 영역 |
+|---|--------|-----------|----------|
+| 1 | Security Reviewer | `review/security-reviewer.md` | 인증/인가, 입력 검증, 시크릿 관리, 취약점 |
+| 2 | Architecture Reviewer | `review/architecture-reviewer.md` | 패키지 구조, 계층 분리, 의존성 방향, 도메인 설계 |
+| 3 | Performance Reviewer | `review/performance-reviewer.md` | JPA N+1, 쿼리 최적화, 캐싱, 비동기 처리 |
+| 4 | Code Quality Reviewer | `review/code-quality-reviewer.md` | 클린 코드, 네이밍, 중복, 에러 처리, 테스트 |
+| 5 | Infrastructure Reviewer | `review/infra-reviewer.md` | CI/CD, 배포 스크립트, 환경 설정, 모니터링 |
+| 6 | API Design Reviewer | `review/api-design-reviewer.md` | REST 설계, 응답 포맷, 에러 응답, 일관성 |
+| 7 | DB Schema Reviewer | `review/db-schema-reviewer.md` | 스키마 설계, 인덱싱, Flyway 마이그레이션, 정규화 |
+
+## 실행 프로세스
+
+### Phase 1: 프로젝트 컨텍스트 수집
+
+리뷰 시작 전 다음 파일들을 읽어 프로젝트 전체 맥락을 파악합니다:
+
+1. `.claude/CLAUDE.md` — 프로젝트 개요
+2. `.claude/docs/architecture.md` — 아키텍처 문서 (존재 시)
+3. `coderabbit_rules.md` — 코딩 컨벤션
+4. `build.gradle` — 의존성 및 빌드 설정
+5. `src/main/resources/application.yml` — 애플리케이션 설정
+
+### Phase 2: 서브 에이전트 순차 실행
+
+아래 순서로 각 리뷰어를 호출합니다. 각 리뷰어는 자신의 영역을 분석한 후 구조화된 리포트를 반환합니다.
+
+**실행 순서** (의존성 고려):
+1. **DB Schema Reviewer** → 스키마 구조 파악이 다른 리뷰의 기반
+2. **Architecture Reviewer** → 구조 파악이 이후 리뷰의 컨텍스트 제공
+3. **Security Reviewer** → 보안 이슈는 우선순위가 높음
+4. **Performance Reviewer** → JPA/쿼리 분석 (기존 `jpa-analyzer` 에이전트 활용)
+5. **Code Quality Reviewer** → 코드 품질 전반 (기존 `code-reviewer` 에이전트 활용)
+6. **API Design Reviewer** → API 설계 검토
+7. **Infrastructure Reviewer** → 인프라/배포 검토
+
+각 리뷰어 호출 시 다음을 전달합니다:
+- 프로젝트 컨텍스트 요약
+- 이전 리뷰어의 핵심 발견 사항 (Cross-reference 용)
+
+### Phase 3: 결과 통합 및 문서화
+
+각 리뷰어의 결과를 수집한 후:
+
+1. **개별 리뷰 문서 생성** — `docs/review/` 하위에 각 분야별 md 파일 작성
+2. **종합 리뷰 문서 생성** — `docs/review/summary.md`에 전체 요약 작성
+
+## 문서 출력 규격
+
+### 개별 리뷰 문서 (`docs/review/{분야}-review.md`)
+
+```markdown
+# {분야} Review — Forgather Backend
+
+> 리뷰 일시: {날짜}
+> 리뷰 범위: {분석 대상 파일/디렉토리}
+
+## 요약
+
+- Critical: {N}건
+- Major: {N}건
+- Minor: {N}건
+
+---
+
+## Critical Issues
+
+### [C-01] {이슈 제목}
+
+**위치**: `파일경로:라인번호`
+
+**현재 코드**:
+```java
+// 문제가 되는 코드
+```
+
+**문제점**: 구체적인 문제 설명
+
+**개선안**:
+```java
+// 개선된 코드
+```
+
+**면접 포인트**: 이 이슈를 개선하면 면접에서 어필할 수 있는 포인트.
+예) "N+1 문제를 Fetch Join으로 해결하여 쿼리 수를 N+1 → 1로 줄인 경험"
+
+---
+
+## Major Issues
+
+### [M-01] {이슈 제목}
+(동일 형식)
+
+---
+
+## Minor Issues
+
+### [m-01] {이슈 제목}
+(동일 형식)
+```
+
+### 종합 리뷰 문서 (`docs/review/summary.md`)
+
+```markdown
+# Forgather Backend — 종합 코드 리뷰
+
+> 리뷰 일시: {날짜}
+
+## Executive Summary
+
+프로젝트 전반에 대한 2-3문장 요약 평가.
+
+## 분야별 요약
+
+| 분야 | Critical | Major | Minor | 상세 문서 |
+|------|----------|-------|-------|----------|
+| Security | N | N | N | [security-review.md](./security-review.md) |
+| Architecture | N | N | N | [architecture-review.md](./architecture-review.md) |
+| Performance | N | N | N | [performance-review.md](./performance-review.md) |
+| Code Quality | N | N | N | [code-quality-review.md](./code-quality-review.md) |
+| Infrastructure | N | N | N | [infra-review.md](./infra-review.md) |
+| API Design | N | N | N | [api-design-review.md](./api-design-review.md) |
+| DB Schema | N | N | N | [db-schema-review.md](./db-schema-review.md) |
+
+## Top 10 Priority Issues
+
+전체 리뷰에서 가장 우선적으로 해결해야 할 이슈 10개를 선별하여 나열.
+
+| 순위 | 분야 | 심각도 | 이슈 | 예상 작업량 | 면접 어필 포인트 |
+|------|------|--------|------|-----------|----------------|
+| 1 | ... | Critical | ... | ... | ... |
+
+## 리팩토링 로드맵
+
+### Phase 1: Critical 이슈 해결 (1주)
+- ...
+
+### Phase 2: Major 이슈 해결 (2주)
+- ...
+
+### Phase 3: Minor 이슈 및 개선 (지속적)
+- ...
+```
+
+## 오버엔지니어링 방지 원칙
+
+모든 리뷰어는 다음 원칙을 준수합니다:
+
+1. **현재 규모에 맞는 제안만 한다** — Forgather는 우아한테크코스 팀 프로젝트로, 트래픽은 제한적이고 팀 규모는 소규모다. 대규모 분산 시스템 수준의 기술을 "도입하라"고 제안하지 않는다.
+2. **"지금 필요한 것"과 "알아두면 좋은 것"을 명확히 구분한다** — 현재 적용해야 할 개선과, 규모가 커지면 고려할 수 있는 기술을 분리한다.
+3. **심화 기술은 "Further Consideration" 섹션에 정리한다** — 각 리뷰 문서 하단에 별도 섹션으로 "현재는 불필요하지만 규모 확장 시 고려할 수 있는 기술"을 간략히 언급한다.
+
+**잘못된 제안 예시:**
+> "Kafka를 도입하여 이벤트 기반 아키텍처로 전환해야 합니다"
+> "Redis Cluster를 구성하여 캐싱 레이어를 추가해야 합니다"
+> "CQRS 패턴을 적용하여 읽기/쓰기를 분리해야 합니다"
+
+**올바른 제안 예시:**
+> "현재 Spring Event로 충분히 처리 가능합니다. 향후 서비스 간 분리가 필요해지면 메시지 브로커(Kafka, SQS 등) 도입을 고려할 수 있습니다."
+> "현재 트래픽 수준에서는 Spring Cache + ConcurrentHashMap으로 충분합니다. 다중 인스턴스 환경에서는 Redis를 고려할 수 있습니다."
+
+### 리뷰 문서 하단 섹션 형식
+
+```markdown
+## Further Consideration (규모 확장 시)
+
+현재 프로젝트 규모에서는 불필요하지만, 서비스가 성장하면 고려할 수 있는 기술입니다.
+
+| 현재 방식 | 확장 시 대안 | 전환 시점 기준 |
+|----------|------------|-------------|
+| Spring Event | Kafka / SQS | 서비스 분리, 이벤트 유실 방지 필요 시 |
+| 로컬 캐시 | Redis | 다중 인스턴스 배포, 캐시 일관성 필요 시 |
+| 단일 DB | Read Replica | 읽기 트래픽이 쓰기의 10배 이상일 때 |
+```
+
+## 심각도 기준
+
+| 심각도 | 기준 | 예시 |
+|--------|------|------|
+| **Critical** | 보안 취약점, 데이터 유실 위험, 프로덕션 장애 가능성 | SQL Injection, 인증 우회, N+1로 인한 DB 과부하 |
+| **Major** | 유지보수성 저하, 성능 병목, 설계 위반 | 계층 간 의존성 역전, 불필요한 엔티티 노출, 인덱스 미적용 |
+| **Minor** | 코드 스타일, 컨벤션 위반, 개선 권장 사항 | 네이밍 불일치, 매직 넘버, 누락된 테스트 |
+
+## 주의사항
+
+1. 각 리뷰어의 결과를 있는 그대로 전달하되, 중복되는 이슈는 가장 관련도 높은 분야의 문서에만 기재
+2. 면접 포인트는 구체적이고 STAR 기법(Situation-Task-Action-Result)으로 어필할 수 있게 작성
+3. 개선안은 반드시 실행 가능한 코드를 포함
+4. 리팩토링 로드맵은 의존 관계를 고려한 실행 순서로 정렬

--- a/.claude/plans/host-spaces-modal.md
+++ b/.claude/plans/host-spaces-modal.md
@@ -1,0 +1,160 @@
+# 호스트 스페이스 목록 모달 구현 계획
+
+## 개요
+호스트 관리 페이지에서 각 호스트의 "스페이스 개수"를 클릭하면 모달이 열리고, 해당 호스트의 전체 스페이스 목록을 스크롤하면서 확인할 수 있는 기능 구현
+
+## 사용 API
+- **엔드포인트**: `GET /admin/hosts/{hostId}/spaces`
+- **컨트롤러**: `AdminHostController.getHostSpaces()`
+- **응답 DTO**: `HostSpacesResponse`
+  ```json
+  {
+    "hostId": 1,
+    "hostName": "홍길동",
+    "spaces": [
+      {
+        "id": 1,
+        "code": "e3f6b97f19",
+        "name": "졸업 전시",
+        "isPublic": true,
+        "createdAt": "2025-11-14T10:30:00",
+        "updatedAt": "2025-11-15T12:00:00"
+      }
+    ]
+  }
+  ```
+
+## 현재 상태 분석
+- `hosts/list.html`: 테이블에 ID, 호스트명, 스페이스 개수, 생성일 컬럼 존재
+- `hosts.js`: 스페이스 개수는 `spaceIds.length`로 단순 숫자만 표시 중 (클릭 불가)
+- `api.js`: `getHostSpaces()` 메서드 없음
+- 모달 패턴은 `spaces/list.html` + `spaces.js`에 이미 구현되어 있음 → 동일 패턴 활용
+
+## 구현 단계
+
+### Step 1: api.js에 getHostSpaces() 메서드 추가
+**파일**: `src/main/resources/static/js/admin/api.js`
+
+기존 `getHosts()` 메서드 아래에 추가:
+```javascript
+async getHostSpaces(hostId) {
+    return this.get(`/hosts/${hostId}/spaces`, {});
+}
+```
+
+### Step 2: hosts/list.html에 모달 HTML 추가
+**파일**: `src/main/resources/templates/admin/hosts/list.html`
+
+`<div id="toast">` 바로 위에 모달 HTML 삽입. spaces 페이지 모달 패턴을 그대로 따르되, 내용만 스페이스 목록용으로 변경:
+
+- **모달 오버레이**: `id="hostSpacesModal"`, `display: none`, blur 배경
+- **모달 컨테이너**: 최대 너비 600px, 최대 높이 85vh
+- **모달 헤더**: "호스트명의 스페이스" 제목 + X 닫기 버튼
+- **모달 바디**: 로딩/에러/콘텐츠 3가지 상태
+  - 로딩: 스피너
+  - 에러: 에러 메시지 + 재시도 버튼
+  - 콘텐츠: 스페이스 목록 (스크롤 가능한 리스트)
+- **모달 푸터**: 닫기 버튼
+- **`<style>` 블록**: 모달 애니메이션 CSS (opacity + translateY 트랜지션)
+
+스페이스 목록 아이템 구조 (각 스페이스):
+- 스페이스명 + 공개/비공개 뱃지
+- 스페이스 코드 (서브텍스트)
+- 생성일
+
+### Step 3: hosts.js에 모달 로직 추가
+**파일**: `src/main/resources/static/js/admin/hosts.js`
+
+#### 3-1. 테이블 렌더링 변경
+스페이스 개수 셀을 클릭 가능한 링크 스타일로 변경:
+```html
+<td class="... cursor-pointer text-primary hover:underline"
+    data-host-id="${host.id}"
+    data-host-name="${escapeHtml(host.name)}"
+    onclick="openHostSpacesModal(this)">
+    ${spaceCount}
+</td>
+```
+- 숫자 0이면 클릭 비활성화 (회색, 커서 기본)
+- 숫자 1 이상이면 클릭 가능 (primary 색상, pointer 커서, 호버 시 밑줄)
+
+#### 3-2. 모달 제어 함수
+DOMContentLoaded 안에 추가:
+
+1. **DOM 요소 캐싱**: modal, modalLoading, modalError, modalContent 등
+2. **openHostSpacesModal(element)**:
+   - `data-host-id`, `data-host-name` 추출
+   - 모달 제목에 호스트명 설정
+   - `display: flex` → `requestAnimationFrame` → `.show` 클래스
+   - `body.modal-open` 추가
+   - `loadHostSpaces(hostId)` 호출
+3. **closeHostSpacesModal()**:
+   - `.show` 제거 → `setTimeout(300ms)` → `display: none`
+   - `body.modal-open` 제거
+   - 모달 콘텐츠 초기화
+4. **loadHostSpaces(hostId)**:
+   - 로딩 상태 표시
+   - `API.getHostSpaces(hostId)` 호출
+   - 성공: `renderHostSpaces(spaces)` 호출
+   - 실패: 에러 메시지 표시
+5. **renderHostSpaces(spaces)**:
+   - 빈 목록: "스페이스가 없습니다" 메시지
+   - 있으면: 스페이스 카드 리스트 렌더링
+     - 각 아이템: 이름, 공개/비공개 뱃지, 코드, 생성일
+
+#### 3-3. 모달 닫기 이벤트
+- X 버튼 클릭
+- 오버레이(배경) 클릭
+- ESC 키
+- 푸터 닫기 버튼
+
+### Step 4: hosts.css에 모달 관련 동적 클래스 추가 (필요시)
+**파일**: `src/main/resources/static/css/admin/hosts.css`
+
+현재 비어있음. 모달 애니메이션 CSS는 `list.html`의 `<style>` 블록에 인라인으로 작성 (spaces 페이지와 동일 패턴)
+
+뱃지 스타일이 필요하면 CSS에 추가하거나 Tailwind 인라인 클래스로 처리.
+
+## 디자인 상세
+
+### 스페이스 개수 셀 (테이블)
+| 상태 | 스타일 |
+|------|--------|
+| 0개 | `text-text-muted`, 기본 커서, 클릭 불가 |
+| 1개 이상 | `text-primary font-semibold cursor-pointer hover:underline`, 클릭 시 모달 열림 |
+
+### 모달 스페이스 리스트 아이템
+```
+┌─────────────────────────────────────────────┐
+│  [스페이스명]                    [공개 뱃지] │
+│  코드: e3f6b97f19                           │
+│  생성: 2025.11.14 10:30                     │
+├─────────────────────────────────────────────┤
+│  [다른 스페이스명]             [비공개 뱃지] │
+│  코드: a1b2c3d4e5                           │
+│  생성: 2025.10.20 15:00                     │
+└─────────────────────────────────────────────┘
+```
+
+- 뱃지: 공개(`bg-success/10 text-success`) / 비공개(`bg-danger/10 text-danger`)
+- 리스트: `max-h-[60vh] overflow-y-auto` 스크롤
+- 각 아이템 사이 구분선: `divide-y divide-border-color`
+
+### 모달 애니메이션
+- 열기: opacity 0→1, translateY(20px)→0, scale(0.95)→1 (0.3s ease)
+- 닫기: 역방향 (0.3s ease) → 300ms 후 display:none
+- 배경: `bg-black/60` + `backdrop-filter: blur(4px)`
+
+## 수정 파일 목록
+| 파일 | 변경 내용 |
+|------|-----------|
+| `static/js/admin/api.js` | `getHostSpaces(hostId)` 메서드 추가 |
+| `templates/admin/hosts/list.html` | 모달 HTML + 모달 CSS 애니메이션 추가 |
+| `static/js/admin/hosts.js` | 테이블 셀 클릭 + 모달 열기/닫기/API호출/렌더링 |
+
+## 구현 시 주의사항
+- XSS 방지: `escapeHtml()` 필수 적용 (호스트명, 스페이스명, 코드)
+- 기존 spaces 모달 패턴과 동일한 UX 유지 (애니메이션, 닫기 트리거)
+- 모달 열린 상태에서 body 스크롤 방지 (`body.modal-open`)
+- 접근성: `role="dialog"`, `aria-modal="true"`, `aria-labelledby`
+- ui-ux-pro-max 스킬 사용하여 기존 디자인 시스템 일관성 유지

--- a/src/main/java/com/forgather/back_office/controller/AdminHostController.java
+++ b/src/main/java/com/forgather/back_office/controller/AdminHostController.java
@@ -5,30 +5,41 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.forgather.back_office.annotation.Admin;
 import com.forgather.back_office.dto.AdminHostResponse;
+import com.forgather.back_office.dto.HostSpacesResponse;
 import com.forgather.back_office.model.AdminUser;
 import com.forgather.back_office.service.AdminHostService;
 
 import lombok.RequiredArgsConstructor;
 
 @RestController
-@RequestMapping("/admin")
+@RequestMapping("/admin/hosts")
 @RequiredArgsConstructor
 public class AdminHostController {
 
     private final AdminHostService adminHostService;
 
-    @GetMapping("/hosts")
+    @GetMapping
     public ResponseEntity<AdminHostResponse> getAllHosts(
         @PageableDefault(size = 15, sort = {"id"}, direction = Sort.Direction.DESC)
         Pageable pageable,
         @Admin AdminUser adminUser
     ) {
         var response = adminHostService.getAllHosts(pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{hostId}/spaces")
+    public ResponseEntity<HostSpacesResponse> getHostSpaces(
+        @PathVariable(name = "hostId") Long hostId,
+        @Admin AdminUser adminUser
+    ) {
+        var response = adminHostService.getHostSpaces(hostId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/forgather/back_office/dto/HostDetailResponse.java
+++ b/src/main/java/com/forgather/back_office/dto/HostDetailResponse.java
@@ -1,7 +1,6 @@
 package com.forgather.back_office.dto;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 import com.forgather.global.auth.model.Host;
 
@@ -9,10 +8,10 @@ public record HostDetailResponse(
     Long id,
     String name,
     LocalDateTime createdAt,
-    List<Long> spaceIds
+    long spaceCount
 ) {
 
-    public static HostDetailResponse of(Host host, List<Long> spaceIds) {
-        return new HostDetailResponse(host.getId(), host.getName(), host.getCreatedAt(), spaceIds);
+    public static HostDetailResponse of(Host host, long spaceCount) {
+        return new HostDetailResponse(host.getId(), host.getName(), host.getCreatedAt(), spaceCount);
     }
 }

--- a/src/main/java/com/forgather/back_office/dto/HostSpacesResponse.java
+++ b/src/main/java/com/forgather/back_office/dto/HostSpacesResponse.java
@@ -1,0 +1,23 @@
+package com.forgather.back_office.dto;
+
+import java.util.List;
+
+import com.forgather.domain.space.model.Space;
+import com.forgather.global.auth.model.Host;
+
+public record HostSpacesResponse(
+    Long hostId,
+    String hostName,
+    List<SimpleSpaceResponse> spaces
+) {
+
+    public static HostSpacesResponse of(Host host, List<Space> spaces) {
+        return new HostSpacesResponse(
+            host.getId(),
+            host.getName(),
+            spaces.stream()
+                .map(SimpleSpaceResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/com/forgather/back_office/repository/AdminSpaceHostMapRepository.java
+++ b/src/main/java/com/forgather/back_office/repository/AdminSpaceHostMapRepository.java
@@ -1,0 +1,40 @@
+package com.forgather.back_office.repository;
+
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import com.forgather.back_office.dto.HostDetailResponse;
+import com.forgather.global.auth.model.Host;
+import com.forgather.global.auth.model.SpaceHostMap;
+
+public interface AdminSpaceHostMapRepository {
+
+    @Query(
+        value = """
+            SELECT new com.forgather.back_office.dto.HostDetailResponse(
+                h.id, h.name, h.createdAt,
+                (SELECT COUNT(shm.id)
+                 FROM SpaceHostMap shm JOIN shm.space s
+                 WHERE shm.host = h AND s.deletedAt IS NULL
+                )
+            )
+            FROM Host h
+            """,
+        countQuery = "SELECT COUNT(h) FROM Host h"
+    )
+    Page<HostDetailResponse> findAllHostsWithSpaceCount(Pageable pageable);
+
+    @Query("""
+        SELECT shm
+        FROM SpaceHostMap shm
+        JOIN FETCH shm.space s
+        WHERE shm.host = :host
+        AND s.deletedAt IS NULL
+        ORDER BY s.createdAt DESC
+        """)
+    List<SpaceHostMap> findAllByHostAndDeletedAtIsNullWithSpaceOrderByCreatedAtDesc(@Param("host") Host host);
+}

--- a/src/main/java/com/forgather/back_office/repository/jpa/AdminSpaceHostMapJpaRepository.java
+++ b/src/main/java/com/forgather/back_office/repository/jpa/AdminSpaceHostMapJpaRepository.java
@@ -1,0 +1,8 @@
+package com.forgather.back_office.repository.jpa;
+
+import com.forgather.back_office.repository.AdminSpaceHostMapRepository;
+import com.forgather.back_office.repository.ReadOnlyRepository;
+import com.forgather.domain.space.model.Space;
+
+public interface AdminSpaceHostMapJpaRepository extends ReadOnlyRepository<Space, Long>, AdminSpaceHostMapRepository {
+}

--- a/src/main/java/com/forgather/back_office/service/AdminHostService.java
+++ b/src/main/java/com/forgather/back_office/service/AdminHostService.java
@@ -2,19 +2,17 @@ package com.forgather.back_office.service;
 
 import java.util.List;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.forgather.back_office.dto.AdminHostResponse;
-import com.forgather.back_office.dto.HostDetailResponse;
 import com.forgather.back_office.dto.HostSpacesResponse;
+import com.forgather.back_office.repository.AdminSpaceHostMapRepository;
 import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.HostRepository;
 import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.model.SpaceHostMap;
-import com.forgather.global.auth.repository.SpaceHostMapRepository;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,23 +22,15 @@ import lombok.RequiredArgsConstructor;
 public class AdminHostService {
 
     private final HostRepository hostRepository;
-    private final SpaceHostMapRepository spaceHostMapRepository;
+    private final AdminSpaceHostMapRepository adminSpaceHostMapRepository;
 
     public AdminHostResponse getAllHosts(Pageable pageable) {
-        Page<Host> hosts = hostRepository.findAll(pageable);
-        return AdminHostResponse.from(hosts.map(host -> {
-            List<Long> spaceIds = spaceHostMapRepository.findAllByHostAndDeletedAtIsNullWithSpaceOrderByCreatedAtDesc(
-                    host)
-                .stream()
-                .map(spaceHostMap -> spaceHostMap.getSpace().getId())
-                .toList();
-            return HostDetailResponse.of(host, spaceIds);
-        }));
+        return AdminHostResponse.from(adminSpaceHostMapRepository.findAllHostsWithSpaceCount(pageable));
     }
 
     public HostSpacesResponse getHostSpaces(Long hostId) {
         Host host = hostRepository.getByIdOrThrow(hostId);
-        List<Space> spaces = spaceHostMapRepository
+        List<Space> spaces = adminSpaceHostMapRepository
             .findAllByHostAndDeletedAtIsNullWithSpaceOrderByCreatedAtDesc(host)
             .stream()
             .map(SpaceHostMap::getSpace)

--- a/src/main/java/com/forgather/back_office/service/AdminHostService.java
+++ b/src/main/java/com/forgather/back_office/service/AdminHostService.java
@@ -9,28 +9,43 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.forgather.back_office.dto.AdminHostResponse;
 import com.forgather.back_office.dto.HostDetailResponse;
+import com.forgather.back_office.dto.HostSpacesResponse;
+import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.HostRepository;
 import com.forgather.global.auth.model.Host;
+import com.forgather.global.auth.model.SpaceHostMap;
 import com.forgather.global.auth.repository.SpaceHostMapRepository;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AdminHostService {
 
     private final HostRepository hostRepository;
     private final SpaceHostMapRepository spaceHostMapRepository;
 
-    @Transactional(readOnly = true)
     public AdminHostResponse getAllHosts(Pageable pageable) {
         Page<Host> hosts = hostRepository.findAll(pageable);
         return AdminHostResponse.from(hosts.map(host -> {
-            List<Long> spaceIds = spaceHostMapRepository.findAllByHostAndDeletedAtIsNullWithSpaceOrderByCreatedAtDesc(host)
+            List<Long> spaceIds = spaceHostMapRepository.findAllByHostAndDeletedAtIsNullWithSpaceOrderByCreatedAtDesc(
+                    host)
                 .stream()
                 .map(spaceHostMap -> spaceHostMap.getSpace().getId())
                 .toList();
             return HostDetailResponse.of(host, spaceIds);
         }));
+    }
+
+    public HostSpacesResponse getHostSpaces(Long hostId) {
+        Host host = hostRepository.getByIdOrThrow(hostId);
+        List<Space> spaces = spaceHostMapRepository
+            .findAllByHostAndDeletedAtIsNullWithSpaceOrderByCreatedAtDesc(host)
+            .stream()
+            .map(SpaceHostMap::getSpace)
+            .toList();
+
+        return HostSpacesResponse.of(host, spaces);
     }
 }

--- a/src/main/resources/static/js/admin/api.js
+++ b/src/main/resources/static/js/admin/api.js
@@ -301,7 +301,7 @@ const API = {
      * - id: Host ID (숫자)
      * - name: Host 이름 (문자열)
      * - createdAt: 생성 일시 (ISO 8601 문자열)
-     * - spaceIds: 소유한 Space ID 배열 (숫자 배열)
+     * - spaceCount: 소유한 Space 개수 (숫자)
      *
      * 사용 예시:
      * ```javascript

--- a/src/main/resources/static/js/admin/api.js
+++ b/src/main/resources/static/js/admin/api.js
@@ -321,6 +321,29 @@ const API = {
      */
     async getHosts(page = 1, size = 15, sort = 'createdAt,desc') {
         return this.get('/hosts', {page, size, sort});
+    },
+
+    /**
+     * 특정 Host의 스페이스 목록 조회 API
+     *
+     * @param {number} hostId - 조회할 호스트 ID
+     * @returns {Promise<object>} 호스트 스페이스 목록 응답 (HostSpacesResponse)
+     * @returns {number} response.hostId - 호스트 ID
+     * @returns {string} response.hostName - 호스트 이름
+     * @returns {Array} response.spaces - 스페이스 목록 배열
+     *
+     * Space 객체 구조:
+     * - id: Space ID (숫자)
+     * - code: Space 코드 (문자열)
+     * - name: Space 이름 (문자열)
+     * - isPublic: 공개 여부 (boolean)
+     * - createdAt: 생성 일시 (ISO 8601 문자열)
+     * - updatedAt: 수정 일시 (ISO 8601 문자열)
+     *
+     * 엔드포인트: GET /admin/hosts/{hostId}/spaces
+     */
+    async getHostSpaces(hostId) {
+        return this.get(`/hosts/${hostId}/spaces`, {});
     }
 };
 

--- a/src/main/resources/static/js/admin/hosts.js
+++ b/src/main/resources/static/js/admin/hosts.js
@@ -308,11 +308,22 @@ document.addEventListener('DOMContentLoaded', function() {
              * - XSS 방지: escapeHtml 함수로 사용자 입력값 이스케이프
              * - 날짜 포맷팅: formatDateTime 함수 사용
              */
+            /**
+             * 스페이스 개수 셀 스타일 분기
+             * - 0개: 회색 비활성 텍스트, 클릭 불가
+             * - 1개 이상: primary 색상, 클릭 가능 (모달 열기)
+             */
+            const spaceCountCell = spaceCount > 0
+                ? `<td class="px-6 py-4 text-sm text-primary font-semibold text-center cursor-pointer hover:underline transition-colors duration-150"
+                       data-host-id="${host.id}" data-host-name="${escapeHtml(host.name)}"
+                       role="button" tabindex="0">${spaceCount}</td>`
+                : `<td class="px-6 py-4 text-sm text-text-muted text-center">${spaceCount}</td>`;
+
             return `
                 <tr class="hover:bg-bg-color transition-colors duration-150">
                     <td class="px-6 py-4 text-sm text-text-primary">${host.id}</td>
                     <td class="px-6 py-4 text-sm text-text-primary font-medium truncate max-w-0" title="${escapeHtml(host.name)}">${escapeHtml(host.name)}</td>
-                    <td class="px-6 py-4 text-sm text-text-primary text-center">${spaceCount}</td>
+                    ${spaceCountCell}
                     <td class="px-6 py-4 text-sm text-text-secondary">${formatDateTime(host.createdAt)}</td>
                 </tr>
             `;
@@ -597,6 +608,218 @@ document.addEventListener('DOMContentLoaded', function() {
         else if (event.key === 'ArrowRight' && currentPage < totalPages) {
             event.preventDefault();
             goToPage(currentPage + 1);
+        }
+    });
+
+    // ======================================================================
+    // Modal Logic - 호스트 스페이스 목록
+    // ======================================================================
+
+    /**
+     * 모달 관련 DOM 요소 참조
+     */
+    const hostSpacesModal = document.getElementById('hostSpacesModal');
+    const hostSpacesModalTitle = document.getElementById('hostSpacesModalTitle');
+    const hostSpacesLoading = document.getElementById('hostSpacesLoading');
+    const hostSpacesError = document.getElementById('hostSpacesError');
+    const hostSpacesContent = document.getElementById('hostSpacesContent');
+    const closeHostSpacesModalBtn = document.getElementById('closeHostSpacesModalBtn');
+    const closeHostSpacesFooterBtn = document.getElementById('closeHostSpacesFooterBtn');
+
+    /**
+     * 모달 열기
+     * - display: flex로 변경 후 다음 프레임에서 .show 추가 (CSS 애니메이션)
+     * - body에 modal-open 추가하여 배경 스크롤 방지
+     */
+    function openHostSpacesModal() {
+        hostSpacesModal.style.display = 'flex';
+        requestAnimationFrame(() => {
+            hostSpacesModal.classList.add('show');
+        });
+        document.body.classList.add('modal-open');
+    }
+
+    /**
+     * 모달 닫기
+     * - .show 제거 후 300ms 대기 (CSS transition과 동일) → display: none
+     * - 모달 내용 초기화
+     */
+    function closeHostSpacesModal() {
+        hostSpacesModal.classList.remove('show');
+        document.body.classList.remove('modal-open');
+
+        setTimeout(() => {
+            hostSpacesModal.style.display = 'none';
+            resetHostSpacesModal();
+        }, 300);
+    }
+
+    /**
+     * 모달 내용 초기화
+     */
+    function resetHostSpacesModal() {
+        hostSpacesLoading.style.display = 'none';
+        hostSpacesError.style.display = 'none';
+        hostSpacesContent.style.display = 'none';
+        hostSpacesContent.innerHTML = '';
+    }
+
+    /**
+     * 모달 로딩 상태 표시
+     */
+    function showHostSpacesLoading() {
+        resetHostSpacesModal();
+        hostSpacesLoading.style.display = 'flex';
+    }
+
+    /**
+     * 모달 에러 상태 표시
+     * @param {string} message - 에러 메시지
+     */
+    function showHostSpacesError(message) {
+        resetHostSpacesModal();
+        hostSpacesError.textContent = message;
+        hostSpacesError.style.display = 'block';
+    }
+
+    /**
+     * 스페이스 목록 렌더링
+     * @param {Array} spaces - SimpleSpaceResponse 배열
+     *
+     * 각 아이템 구조:
+     * - 스페이스명 + 공개/비공개 뱃지
+     * - 스페이스 코드
+     * - 생성일
+     */
+    function renderHostSpaces(spaces) {
+        resetHostSpacesModal();
+
+        if (!spaces || spaces.length === 0) {
+            hostSpacesContent.innerHTML = `
+                <div class="flex flex-col items-center justify-center py-2xl text-text-secondary">
+                    <svg class="w-12 h-12 mb-md text-text-muted opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
+                    </svg>
+                    <p class="text-sm">스페이스가 없습니다.</p>
+                </div>
+            `;
+            hostSpacesContent.style.display = 'block';
+            return;
+        }
+
+        const items = spaces.map(space => {
+            const publicBadge = space.isPublic
+                ? '<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-success/10 text-success">공개</span>'
+                : '<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-danger/10 text-danger">비공개</span>';
+
+            return `
+                <div class="py-md">
+                    <div class="flex items-center justify-between mb-1">
+                        <span class="text-sm font-medium text-text-primary">${escapeHtml(space.name)}</span>
+                        ${publicBadge}
+                    </div>
+                    <div class="flex items-center gap-lg text-xs text-text-secondary">
+                        <span class="font-mono">${escapeHtml(space.code)}</span>
+                        <span>${formatDateTime(space.createdAt)}</span>
+                    </div>
+                </div>
+            `;
+        }).join('');
+
+        hostSpacesContent.innerHTML = items;
+        hostSpacesContent.style.display = 'block';
+    }
+
+    /**
+     * 호스트 스페이스 목록 로드
+     *
+     * @param {number} hostId - 호스트 ID
+     * @param {string} hostName - 호스트 이름 (모달 제목에 표시)
+     *
+     * 동작 흐름:
+     * 1. 모달 제목에 호스트명 설정
+     * 2. 모달 열기 + 로딩 표시
+     * 3. API 호출 (API.getHostSpaces)
+     * 4. 성공: 스페이스 목록 렌더링 / 실패: 에러 메시지 표시
+     */
+    async function loadHostSpaces(hostId, hostName) {
+        hostSpacesModalTitle.textContent = `${hostName}의 스페이스`;
+        openHostSpacesModal();
+        showHostSpacesLoading();
+
+        try {
+            const data = await API.getHostSpaces(hostId);
+            renderHostSpaces(data.spaces);
+        } catch (error) {
+            console.error('Failed to load host spaces:', error);
+            showHostSpacesError(error.message || '스페이스 목록을 불러오는데 실패했습니다.');
+        }
+    }
+
+    /**
+     * 테이블 바디 클릭 이벤트 핸들러 (이벤트 위임)
+     * - 스페이스 개수 셀(data-host-id) 클릭 시 모달 열기
+     */
+    hostsTableBody.addEventListener('click', function(event) {
+        const td = event.target.closest('td[data-host-id]');
+        if (td) {
+            const hostId = td.getAttribute('data-host-id');
+            const hostName = td.getAttribute('data-host-name');
+            if (hostId) {
+                loadHostSpaces(parseInt(hostId), hostName);
+            }
+        }
+    });
+
+    /**
+     * 스페이스 개수 셀 키보드 이벤트 (접근성)
+     * - Enter 또는 Space 키로 모달 열기
+     */
+    hostsTableBody.addEventListener('keydown', function(event) {
+        if (event.key === 'Enter' || event.key === ' ') {
+            const td = event.target.closest('td[data-host-id]');
+            if (td) {
+                event.preventDefault();
+                const hostId = td.getAttribute('data-host-id');
+                const hostName = td.getAttribute('data-host-name');
+                if (hostId) {
+                    loadHostSpaces(parseInt(hostId), hostName);
+                }
+            }
+        }
+    });
+
+    /**
+     * 모달 닫기: 헤더 X 버튼
+     */
+    closeHostSpacesModalBtn.addEventListener('click', function() {
+        closeHostSpacesModal();
+    });
+
+    /**
+     * 모달 닫기: 푸터 닫기 버튼
+     */
+    closeHostSpacesFooterBtn.addEventListener('click', function() {
+        closeHostSpacesModal();
+    });
+
+    /**
+     * 모달 닫기: 오버레이(배경) 클릭
+     * - event.target === hostSpacesModal이면 오버레이 직접 클릭
+     */
+    hostSpacesModal.addEventListener('click', function(event) {
+        if (event.target === hostSpacesModal) {
+            closeHostSpacesModal();
+        }
+    });
+
+    /**
+     * 모달 닫기: ESC 키
+     * - 모달이 열려있을 때만 동작
+     */
+    document.addEventListener('keydown', function(event) {
+        if (event.key === 'Escape' && hostSpacesModal.classList.contains('show')) {
+            closeHostSpacesModal();
         }
     });
 

--- a/src/main/resources/static/js/admin/hosts.js
+++ b/src/main/resources/static/js/admin/hosts.js
@@ -594,7 +594,7 @@ document.addEventListener('DOMContentLoaded', function() {
             activeElement.isContentEditable
         );
 
-        if (isInputFocused) {
+        if (isInputFocused || hostSpacesModal.classList.contains('show')) {
             return;
         }
 
@@ -635,6 +635,19 @@ document.addEventListener('DOMContentLoaded', function() {
     const spaceDetailLoading = document.getElementById('spaceDetailLoading');
     const spaceDetailError = document.getElementById('spaceDetailError');
     const spaceDetailContent = document.getElementById('spaceDetailContent');
+
+    // 상세 패널 DOM 요소 캐싱
+    const detailSpaceId = document.getElementById('detailSpaceId');
+    const detailSpaceCode = document.getElementById('detailSpaceCode');
+    const detailSpaceName = document.getElementById('detailSpaceName');
+    const detailSpacePublic = document.getElementById('detailSpacePublic');
+    const detailProductCount = document.getElementById('detailProductCount');
+    const detailGuestBookCount = document.getElementById('detailGuestBookCount');
+    const detailCreatedAt = document.getElementById('detailCreatedAt');
+    const detailUpdatedAt = document.getElementById('detailUpdatedAt');
+
+    /** CSS transition duration과 동기화된 모달 전환 시간(ms) */
+    const MODAL_TRANSITION_MS = 300;
 
     /**
      * 모달 내부 슬라이드 상태 관리
@@ -679,7 +692,7 @@ document.addEventListener('DOMContentLoaded', function() {
             currentDetailSpaceCode = null;
             savedModalTitle = '';
             resetSpaceDetailPanel();
-        }, 300);
+        }, MODAL_TRANSITION_MS);
     }
 
     /**
@@ -705,14 +718,14 @@ document.addEventListener('DOMContentLoaded', function() {
         spaceDetailLoading.style.display = 'none';
         spaceDetailError.style.display = 'none';
         spaceDetailContent.style.display = 'none';
-        document.getElementById('detailSpaceId').textContent = '-';
-        document.getElementById('detailSpaceCode').textContent = '-';
-        document.getElementById('detailSpaceName').textContent = '-';
-        document.getElementById('detailSpacePublic').innerHTML = '-';
-        document.getElementById('detailProductCount').textContent = '-';
-        document.getElementById('detailGuestBookCount').textContent = '-';
-        document.getElementById('detailCreatedAt').textContent = '-';
-        document.getElementById('detailUpdatedAt').textContent = '-';
+        detailSpaceId.textContent = '-';
+        detailSpaceCode.textContent = '-';
+        detailSpaceName.textContent = '-';
+        detailSpacePublic.innerHTML = '-';
+        detailProductCount.textContent = '-';
+        detailGuestBookCount.textContent = '-';
+        detailCreatedAt.textContent = '-';
+        detailUpdatedAt.textContent = '-';
     }
 
     /**
@@ -746,7 +759,7 @@ document.addEventListener('DOMContentLoaded', function() {
             resetSpaceDetailPanel();
             // 목록 패널 스크롤 인디케이터 복원
             requestAnimationFrame(() => updateScrollFade());
-        }, 300);
+        }, MODAL_TRANSITION_MS);
     }
 
     /**
@@ -770,6 +783,17 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     /**
+     * 공개/비공개 뱃지 HTML 생성
+     * @param {boolean} isPublic - 공개 여부
+     * @returns {string} 뱃지 HTML 문자열
+     */
+    function createPublicBadge(isPublic) {
+        return isPublic
+            ? '<span class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold bg-success/10 text-success">공개</span>'
+            : '<span class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold bg-danger/10 text-danger">비공개</span>';
+    }
+
+    /**
      * 상세 패널 콘텐츠 렌더링
      * @param {object} data - SpaceDetailResponse (space, productCount, guestBookCount)
      */
@@ -779,19 +803,15 @@ document.addEventListener('DOMContentLoaded', function() {
 
         const space = data.space;
 
-        document.getElementById('detailSpaceId').textContent = space.id;
-        document.getElementById('detailSpaceCode').textContent = space.code;
-        document.getElementById('detailSpaceName').textContent = space.name;
+        detailSpaceId.textContent = space.id;
+        detailSpaceCode.textContent = space.code;
+        detailSpaceName.textContent = space.name;
+        detailSpacePublic.innerHTML = createPublicBadge(space.isPublic);
 
-        const publicBadge = space.isPublic
-            ? '<span class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold bg-success/10 text-success">공개</span>'
-            : '<span class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold bg-danger/10 text-danger">비공개</span>';
-        document.getElementById('detailSpacePublic').innerHTML = publicBadge;
-
-        document.getElementById('detailProductCount').textContent = `${data.productCount}개`;
-        document.getElementById('detailGuestBookCount').textContent = `${data.guestBookCount}개`;
-        document.getElementById('detailCreatedAt').textContent = formatDateTime(space.createdAt);
-        document.getElementById('detailUpdatedAt').textContent = formatDateTime(space.updatedAt);
+        detailProductCount.textContent = `${data.productCount}개`;
+        detailGuestBookCount.textContent = `${data.guestBookCount}개`;
+        detailCreatedAt.textContent = formatDateTime(space.createdAt);
+        detailUpdatedAt.textContent = formatDateTime(space.updatedAt);
 
         spaceDetailContent.style.display = 'block';
     }
@@ -808,8 +828,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
         try {
             const data = await API.getSpaceDetail(spaceCode);
+            if (currentDetailSpaceCode !== spaceCode) return;
             showSpaceDetailContent(data);
         } catch (error) {
+            if (currentDetailSpaceCode !== spaceCode) return;
             console.error('Failed to load space detail:', error);
             showSpaceDetailError(error.message || '스페이스 정보를 불러오는데 실패했습니다.');
         }
@@ -822,16 +844,9 @@ document.addEventListener('DOMContentLoaded', function() {
      */
     function getSpacePageUrl(spaceCode) {
         const hostname = window.location.hostname;
-
-        let guestDomain;
-        if (hostname === 'api.forgather.app') {
-            guestDomain = 'forgather.app';
-        } else if (hostname === 'api.dev.forgather.app') {
-            guestDomain = 'dev.forgather.app';
-        } else {
-            guestDomain = 'dev.forgather.app';
-        }
-
+        const guestDomain = hostname.startsWith('api.')
+            ? hostname.substring(4)
+            : 'dev.forgather.app';
         return `https://${guestDomain}/guest/${spaceCode}/home`;
     }
 
@@ -868,7 +883,9 @@ document.addEventListener('DOMContentLoaded', function() {
         hostSpacesScrollFade.style.display = (isScrollable && !isAtBottom) ? 'block' : 'none';
     }
 
-    hostSpacesScrollArea.addEventListener('scroll', updateScrollFade);
+    if (hostSpacesScrollArea) {
+        hostSpacesScrollArea.addEventListener('scroll', updateScrollFade);
+    }
 
     /**
      * 스페이스 목록 렌더링
@@ -894,9 +911,7 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         const items = spaces.map((space, index) => {
-            const publicBadge = space.isPublic
-                ? '<span class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold bg-success/10 text-success">공개</span>'
-                : '<span class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold bg-danger/10 text-danger">비공개</span>';
+            const publicBadge = createPublicBadge(space.isPublic);
 
             return `
                 <div class="p-md rounded-lg border border-border-color bg-bg-color transition-colors duration-150 space-card-clickable ${index > 0 ? 'mt-sm' : ''}"
@@ -963,19 +978,26 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     /**
-     * 테이블 바디 클릭 이벤트 핸들러 (이벤트 위임)
-     * - 스페이스 개수 셀(data-host-id) 클릭 시 모달 열기
+     * 호스트 셀 활성화 공통 처리
+     * - data-host-id 셀을 찾아 모달 열기
+     * @param {Event} event - DOM 이벤트
      */
-    hostsTableBody.addEventListener('click', function(event) {
+    function handleHostCellActivation(event) {
         const td = event.target.closest('td[data-host-id]');
         if (td) {
             const hostId = td.getAttribute('data-host-id');
             const hostName = td.getAttribute('data-host-name');
             if (hostId) {
-                loadHostSpaces(parseInt(hostId), hostName);
+                loadHostSpaces(parseInt(hostId, 10), hostName);
             }
         }
-    });
+    }
+
+    /**
+     * 테이블 바디 클릭 이벤트 핸들러 (이벤트 위임)
+     * - 스페이스 개수 셀(data-host-id) 클릭 시 모달 열기
+     */
+    hostsTableBody.addEventListener('click', handleHostCellActivation);
 
     /**
      * 스페이스 개수 셀 키보드 이벤트 (접근성)
@@ -983,15 +1005,8 @@ document.addEventListener('DOMContentLoaded', function() {
      */
     hostsTableBody.addEventListener('keydown', function(event) {
         if (event.key === 'Enter' || event.key === ' ') {
-            const td = event.target.closest('td[data-host-id]');
-            if (td) {
-                event.preventDefault();
-                const hostId = td.getAttribute('data-host-id');
-                const hostName = td.getAttribute('data-host-name');
-                if (hostId) {
-                    loadHostSpaces(parseInt(hostId), hostName);
-                }
-            }
+            event.preventDefault();
+            handleHostCellActivation(event);
         }
     });
 

--- a/src/main/resources/static/js/admin/hosts.js
+++ b/src/main/resources/static/js/admin/hosts.js
@@ -623,6 +623,9 @@ document.addEventListener('DOMContentLoaded', function() {
     const hostSpacesLoading = document.getElementById('hostSpacesLoading');
     const hostSpacesError = document.getElementById('hostSpacesError');
     const hostSpacesContent = document.getElementById('hostSpacesContent');
+    const hostSpacesScrollArea = document.getElementById('hostSpacesScrollArea');
+    const hostSpacesScrollFade = document.getElementById('hostSpacesScrollFade');
+    const hostSpacesCountInfo = document.getElementById('hostSpacesCountInfo');
     const closeHostSpacesModalBtn = document.getElementById('closeHostSpacesModalBtn');
     const closeHostSpacesFooterBtn = document.getElementById('closeHostSpacesFooterBtn');
 
@@ -662,6 +665,8 @@ document.addEventListener('DOMContentLoaded', function() {
         hostSpacesError.style.display = 'none';
         hostSpacesContent.style.display = 'none';
         hostSpacesContent.innerHTML = '';
+        hostSpacesScrollFade.style.display = 'none';
+        hostSpacesCountInfo.textContent = '';
     }
 
     /**
@@ -683,13 +688,27 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     /**
+     * 스크롤 페이드 인디케이터 업데이트
+     * - 스크롤 가능할 때 하단 페이드 표시
+     * - 스크롤이 끝에 도달하면 페이드 숨김
+     */
+    function updateScrollFade() {
+        if (!hostSpacesScrollArea || !hostSpacesScrollFade) return;
+
+        const { scrollTop, scrollHeight, clientHeight } = hostSpacesScrollArea;
+        const isScrollable = scrollHeight > clientHeight + 4;
+        const isAtBottom = scrollTop + clientHeight >= scrollHeight - 4;
+
+        hostSpacesScrollFade.style.display = (isScrollable && !isAtBottom) ? 'block' : 'none';
+    }
+
+    hostSpacesScrollArea.addEventListener('scroll', updateScrollFade);
+
+    /**
      * 스페이스 목록 렌더링
      * @param {Array} spaces - SimpleSpaceResponse 배열
      *
-     * 각 아이템 구조:
-     * - 스페이스명 + 공개/비공개 뱃지
-     * - 스페이스 코드
-     * - 생성일
+     * 각 아이템: 카드 형태, 라벨 표기 (이름, 코드, 생성일, 공개 여부)
      */
     function renderHostSpaces(spaces) {
         resetHostSpacesModal();
@@ -704,23 +723,33 @@ document.addEventListener('DOMContentLoaded', function() {
                 </div>
             `;
             hostSpacesContent.style.display = 'block';
+            hostSpacesCountInfo.textContent = '';
             return;
         }
 
-        const items = spaces.map(space => {
+        const items = spaces.map((space, index) => {
             const publicBadge = space.isPublic
-                ? '<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-success/10 text-success">공개</span>'
-                : '<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-danger/10 text-danger">비공개</span>';
+                ? '<span class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold bg-success/10 text-success">공개</span>'
+                : '<span class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold bg-danger/10 text-danger">비공개</span>';
 
             return `
-                <div class="py-md">
-                    <div class="flex items-center justify-between mb-1">
-                        <span class="text-sm font-medium text-text-primary">${escapeHtml(space.name)}</span>
+                <div class="p-md rounded-lg border border-border-color bg-bg-color hover:border-neutral-300 transition-colors duration-150 ${index > 0 ? 'mt-sm' : ''}">
+                    <div class="flex items-start justify-between gap-md mb-2">
+                        <div class="flex items-center gap-sm min-w-0">
+                            <span class="text-xs font-medium text-text-muted whitespace-nowrap">이름</span>
+                            <span class="text-sm font-semibold text-text-primary truncate">${escapeHtml(space.name)}</span>
+                        </div>
                         ${publicBadge}
                     </div>
-                    <div class="flex items-center gap-lg text-xs text-text-secondary">
-                        <span class="font-mono">${escapeHtml(space.code)}</span>
-                        <span>${formatDateTime(space.createdAt)}</span>
+                    <div class="grid grid-cols-2 gap-x-lg gap-y-1">
+                        <div class="flex items-center gap-sm">
+                            <span class="text-xs font-medium text-text-muted whitespace-nowrap">코드</span>
+                            <span class="text-xs font-mono text-text-secondary truncate">${escapeHtml(space.code)}</span>
+                        </div>
+                        <div class="flex items-center gap-sm">
+                            <span class="text-xs font-medium text-text-muted whitespace-nowrap">생성일</span>
+                            <span class="text-xs text-text-secondary">${formatDateTime(space.createdAt)}</span>
+                        </div>
                     </div>
                 </div>
             `;
@@ -728,6 +757,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
         hostSpacesContent.innerHTML = items;
         hostSpacesContent.style.display = 'block';
+        hostSpacesCountInfo.textContent = `총 ${spaces.length}개 스페이스`;
+
+        // 렌더링 후 스크롤 인디케이터 업데이트
+        requestAnimationFrame(() => updateScrollFade());
     }
 
     /**

--- a/src/main/resources/static/js/admin/hosts.js
+++ b/src/main/resources/static/js/admin/hosts.js
@@ -262,7 +262,7 @@ document.addEventListener('DOMContentLoaded', function() {
      * 테이블 컬럼 구성:
      * 1. ID: host.id (숫자)
      * 2. 호스트명: host.name (문자열, XSS 방지를 위해 escapeHtml 적용)
-     * 3. 스페이스 개수: host.spaceIds.length (배열의 길이만 표시)
+     * 3. 스페이스 개수: host.spaceCount (서버에서 COUNT 쿼리로 계산된 값)
      * 4. 생성일: host.createdAt (formatDateTime으로 포맷팅)
      *
      * 빈 상태 처리:
@@ -296,12 +296,11 @@ document.addEventListener('DOMContentLoaded', function() {
          */
         const rows = hosts.map(host => {
             /**
-             * 스페이스 개수 계산
-             * - spaceIds는 배열이므로 .length로 개수 추출
-             * - 배열 자체를 렌더링하면 안 됨 (요구사항 명시)
-             * - 방어적 코드: spaceIds가 없거나 배열이 아닌 경우 0으로 표시
+             * 스페이스 개수
+             * - 서버에서 COUNT 쿼리로 계산된 값을 직접 사용
+             * - 방어적 코드: spaceCount가 없는 경우 0으로 표시
              */
-            const spaceCount = Array.isArray(host.spaceIds) ? host.spaceIds.length : 0;
+            const spaceCount = host.spaceCount || 0;
 
             /**
              * HTML 템플릿 리터럴로 테이블 행 생성

--- a/src/main/resources/static/js/admin/hosts.js
+++ b/src/main/resources/static/js/admin/hosts.js
@@ -629,6 +629,24 @@ document.addEventListener('DOMContentLoaded', function() {
     const closeHostSpacesModalBtn = document.getElementById('closeHostSpacesModalBtn');
     const closeHostSpacesFooterBtn = document.getElementById('closeHostSpacesFooterBtn');
 
+    // 슬라이드 전환 관련 DOM 요소
+    const backToSpaceListBtn = document.getElementById('backToSpaceListBtn');
+    const hostModalVisitSpaceBtn = document.getElementById('hostModalVisitSpaceBtn');
+    const modalPanelContainer = document.getElementById('modalPanelContainer');
+    const spaceDetailLoading = document.getElementById('spaceDetailLoading');
+    const spaceDetailError = document.getElementById('spaceDetailError');
+    const spaceDetailContent = document.getElementById('spaceDetailContent');
+
+    /**
+     * 모달 내부 슬라이드 상태 관리
+     * - currentModalView: 현재 표시 중인 패널 ('list' | 'detail')
+     * - currentDetailSpaceCode: 현재 상세 보기 중인 스페이스 코드
+     * - savedModalTitle: 상세 전환 전 저장한 모달 제목 (복원용)
+     */
+    let currentModalView = 'list';
+    let currentDetailSpaceCode = null;
+    let savedModalTitle = '';
+
     /**
      * 모달 열기
      * - display: flex로 변경 후 다음 프레임에서 .show 추가 (CSS 애니메이션)
@@ -654,6 +672,14 @@ document.addEventListener('DOMContentLoaded', function() {
         setTimeout(() => {
             hostSpacesModal.style.display = 'none';
             resetHostSpacesModal();
+            // 슬라이드 상태 즉시 초기화 (재열기 시 항상 목록부터)
+            modalPanelContainer.style.transform = 'translateX(0%)';
+            backToSpaceListBtn.style.display = 'none';
+            hostModalVisitSpaceBtn.style.display = 'none';
+            currentModalView = 'list';
+            currentDetailSpaceCode = null;
+            savedModalTitle = '';
+            resetSpaceDetailPanel();
         }, 300);
     }
 
@@ -667,6 +693,147 @@ document.addEventListener('DOMContentLoaded', function() {
         hostSpacesContent.innerHTML = '';
         hostSpacesScrollFade.style.display = 'none';
         hostSpacesCountInfo.textContent = '';
+    }
+
+    // ==================================================================
+    // 슬라이드 전환 함수
+    // ==================================================================
+
+    /**
+     * 스페이스 상세 패널 초기화
+     */
+    function resetSpaceDetailPanel() {
+        spaceDetailLoading.style.display = 'none';
+        spaceDetailError.style.display = 'none';
+        spaceDetailContent.style.display = 'none';
+        document.getElementById('detailSpaceId').textContent = '-';
+        document.getElementById('detailSpaceCode').textContent = '-';
+        document.getElementById('detailSpaceName').textContent = '-';
+        document.getElementById('detailSpacePublic').innerHTML = '-';
+        document.getElementById('detailProductCount').textContent = '-';
+        document.getElementById('detailGuestBookCount').textContent = '-';
+        document.getElementById('detailCreatedAt').textContent = '-';
+        document.getElementById('detailUpdatedAt').textContent = '-';
+    }
+
+    /**
+     * 목록 → 상세 슬라이드 전환
+     * @param {string} spaceName - 모달 제목에 표시할 스페이스 이름
+     */
+    function slideToDetail(spaceName) {
+        savedModalTitle = hostSpacesModalTitle.textContent;
+        hostSpacesModalTitle.textContent = spaceName;
+        modalPanelContainer.style.transform = 'translateX(-50%)';
+        backToSpaceListBtn.style.display = 'flex';
+        hostModalVisitSpaceBtn.style.display = 'inline-flex';
+        hostSpacesScrollFade.style.display = 'none';
+        hostSpacesCountInfo.textContent = '';
+        currentModalView = 'detail';
+    }
+
+    /**
+     * 상세 → 목록 슬라이드 복귀
+     */
+    function slideToList() {
+        hostSpacesModalTitle.textContent = savedModalTitle;
+        modalPanelContainer.style.transform = 'translateX(0%)';
+        backToSpaceListBtn.style.display = 'none';
+        hostModalVisitSpaceBtn.style.display = 'none';
+        currentModalView = 'list';
+        currentDetailSpaceCode = null;
+
+        // 슬라이드 애니메이션 완료 후 상세 패널 초기화
+        setTimeout(() => {
+            resetSpaceDetailPanel();
+            // 목록 패널 스크롤 인디케이터 복원
+            requestAnimationFrame(() => updateScrollFade());
+        }, 300);
+    }
+
+    /**
+     * 상세 패널 로딩 상태 표시
+     */
+    function showSpaceDetailLoading() {
+        spaceDetailLoading.style.display = 'flex';
+        spaceDetailError.style.display = 'none';
+        spaceDetailContent.style.display = 'none';
+    }
+
+    /**
+     * 상세 패널 에러 상태 표시
+     * @param {string} message - 에러 메시지
+     */
+    function showSpaceDetailError(message) {
+        spaceDetailLoading.style.display = 'none';
+        spaceDetailError.textContent = message;
+        spaceDetailError.style.display = 'block';
+        spaceDetailContent.style.display = 'none';
+    }
+
+    /**
+     * 상세 패널 콘텐츠 렌더링
+     * @param {object} data - SpaceDetailResponse (space, productCount, guestBookCount)
+     */
+    function showSpaceDetailContent(data) {
+        spaceDetailLoading.style.display = 'none';
+        spaceDetailError.style.display = 'none';
+
+        const space = data.space;
+
+        document.getElementById('detailSpaceId').textContent = space.id;
+        document.getElementById('detailSpaceCode').textContent = space.code;
+        document.getElementById('detailSpaceName').textContent = space.name;
+
+        const publicBadge = space.isPublic
+            ? '<span class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold bg-success/10 text-success">공개</span>'
+            : '<span class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold bg-danger/10 text-danger">비공개</span>';
+        document.getElementById('detailSpacePublic').innerHTML = publicBadge;
+
+        document.getElementById('detailProductCount').textContent = `${data.productCount}개`;
+        document.getElementById('detailGuestBookCount').textContent = `${data.guestBookCount}개`;
+        document.getElementById('detailCreatedAt').textContent = formatDateTime(space.createdAt);
+        document.getElementById('detailUpdatedAt').textContent = formatDateTime(space.updatedAt);
+
+        spaceDetailContent.style.display = 'block';
+    }
+
+    /**
+     * 모달 내 스페이스 상세 로드 + 슬라이드 전환
+     * @param {string} spaceCode - 스페이스 코드
+     * @param {string} spaceName - 스페이스 이름
+     */
+    async function loadSpaceDetailInModal(spaceCode, spaceName) {
+        currentDetailSpaceCode = spaceCode;
+        showSpaceDetailLoading();
+        slideToDetail(spaceName);
+
+        try {
+            const data = await API.getSpaceDetail(spaceCode);
+            showSpaceDetailContent(data);
+        } catch (error) {
+            console.error('Failed to load space detail:', error);
+            showSpaceDetailError(error.message || '스페이스 정보를 불러오는데 실패했습니다.');
+        }
+    }
+
+    /**
+     * 게스트 페이지 URL 생성
+     * @param {string} spaceCode - 스페이스 코드
+     * @returns {string} 게스트 페이지 URL
+     */
+    function getSpacePageUrl(spaceCode) {
+        const hostname = window.location.hostname;
+
+        let guestDomain;
+        if (hostname === 'api.forgather.app') {
+            guestDomain = 'forgather.app';
+        } else if (hostname === 'api.dev.forgather.app') {
+            guestDomain = 'dev.forgather.app';
+        } else {
+            guestDomain = 'dev.forgather.app';
+        }
+
+        return `https://${guestDomain}/guest/${spaceCode}/home`;
     }
 
     /**
@@ -733,13 +900,20 @@ document.addEventListener('DOMContentLoaded', function() {
                 : '<span class="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-semibold bg-danger/10 text-danger">비공개</span>';
 
             return `
-                <div class="p-md rounded-lg border border-border-color bg-bg-color hover:border-neutral-300 transition-colors duration-150 ${index > 0 ? 'mt-sm' : ''}">
+                <div class="p-md rounded-lg border border-border-color bg-bg-color transition-colors duration-150 space-card-clickable ${index > 0 ? 'mt-sm' : ''}"
+                     data-space-code="${escapeHtml(space.code)}" data-space-name="${escapeHtml(space.name)}"
+                     role="button" tabindex="0">
                     <div class="flex items-start justify-between gap-md mb-2">
                         <div class="flex items-center gap-sm min-w-0">
                             <span class="text-xs font-medium text-text-muted whitespace-nowrap">이름</span>
                             <span class="text-sm font-semibold text-text-primary truncate">${escapeHtml(space.name)}</span>
                         </div>
-                        ${publicBadge}
+                        <div class="flex items-center gap-xs shrink-0">
+                            ${publicBadge}
+                            <svg class="w-4 h-4 text-text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
+                            </svg>
+                        </div>
                     </div>
                     <div class="grid grid-cols-2 gap-x-lg gap-y-1">
                         <div class="flex items-center gap-sm">
@@ -848,11 +1022,67 @@ document.addEventListener('DOMContentLoaded', function() {
 
     /**
      * 모달 닫기: ESC 키
-     * - 모달이 열려있을 때만 동작
+     * - 상세 화면: 목록으로 복귀
+     * - 목록 화면: 모달 닫기
      */
     document.addEventListener('keydown', function(event) {
         if (event.key === 'Escape' && hostSpacesModal.classList.contains('show')) {
-            closeHostSpacesModal();
+            if (currentModalView === 'detail') {
+                slideToList();
+            } else {
+                closeHostSpacesModal();
+            }
+        }
+    });
+
+    // ======================================================================
+    // 슬라이드 전환 이벤트 리스너
+    // ======================================================================
+
+    /**
+     * 뒤로가기 버튼 클릭 → 목록 복귀
+     */
+    backToSpaceListBtn.addEventListener('click', function() {
+        slideToList();
+    });
+
+    /**
+     * 게스트 페이지 이동 버튼 클릭
+     */
+    hostModalVisitSpaceBtn.addEventListener('click', function() {
+        if (currentDetailSpaceCode) {
+            window.open(getSpacePageUrl(currentDetailSpaceCode), '_blank');
+        }
+    });
+
+    /**
+     * 스페이스 카드 클릭 → 상세 슬라이드 전환 (이벤트 위임)
+     */
+    hostSpacesContent.addEventListener('click', function(event) {
+        const card = event.target.closest('[data-space-code]');
+        if (card) {
+            const spaceCode = card.getAttribute('data-space-code');
+            const spaceName = card.getAttribute('data-space-name');
+            if (spaceCode) {
+                loadSpaceDetailInModal(spaceCode, spaceName);
+            }
+        }
+    });
+
+    /**
+     * 스페이스 카드 키보드 접근성 (Enter/Space)
+     */
+    hostSpacesContent.addEventListener('keydown', function(event) {
+        if (event.key === 'Enter' || event.key === ' ') {
+            const card = event.target.closest('[data-space-code]');
+            if (card) {
+                event.preventDefault();
+                const spaceCode = card.getAttribute('data-space-code');
+                const spaceName = card.getAttribute('data-space-name');
+                if (spaceCode) {
+                    loadSpaceDetailInModal(spaceCode, spaceName);
+                }
+            }
         }
     });
 

--- a/src/main/resources/templates/admin/hosts/list.html
+++ b/src/main/resources/templates/admin/hosts/list.html
@@ -317,7 +317,7 @@
                     <div class="w-1/2 h-full overflow-y-auto relative p-lg" id="hostSpacesScrollArea">
                         <!-- 로딩 상태 -->
                         <div id="hostSpacesLoading" class="flex flex-col items-center justify-center py-2xl text-text-secondary" style="display: none;">
-                            <div class="w-10 h-10 border-3 border-border-color border-t-primary rounded-full animate-spin"></div>
+                            <div class="w-10 h-10 border-[3px] border-border-color border-t-primary rounded-full animate-spin"></div>
                             <p class="mt-md text-sm">스페이스 목록 로딩 중...</p>
                         </div>
 
@@ -336,7 +336,7 @@
                     <div class="w-1/2 h-full overflow-y-auto p-lg" id="spaceDetailPanel">
                         <!-- 로딩 상태 -->
                         <div id="spaceDetailLoading" class="flex flex-col items-center justify-center py-2xl text-text-secondary" style="display: none;">
-                            <div class="w-10 h-10 border-3 border-border-color border-t-primary rounded-full animate-spin"></div>
+                            <div class="w-10 h-10 border-[3px] border-border-color border-t-primary rounded-full animate-spin"></div>
                             <p class="mt-md text-sm">스페이스 정보 로딩 중...</p>
                         </div>
 

--- a/src/main/resources/templates/admin/hosts/list.html
+++ b/src/main/resources/templates/admin/hosts/list.html
@@ -261,7 +261,7 @@
          class="modal-overlay fixed inset-0 bg-black/60 flex justify-center items-center z-[10000]"
          style="display: none;"
          role="dialog" aria-labelledby="hostSpacesModalTitle" aria-modal="true">
-        <div class="modal-container bg-surface rounded-xl shadow-xl max-w-[600px] w-[90%] max-h-[85vh] flex flex-col">
+        <div class="modal-container bg-surface rounded-xl shadow-xl max-w-[960px] w-[90%] max-h-[85vh] flex flex-col">
             <!-- 모달 헤더 -->
             <div class="flex justify-between items-center p-lg border-b border-border-color">
                 <h3 id="hostSpacesModalTitle" class="text-xl font-bold text-text-primary m-0">스페이스 목록</h3>
@@ -273,8 +273,8 @@
                 </button>
             </div>
 
-            <!-- 모달 내용 -->
-            <div class="p-lg overflow-y-auto flex-1">
+            <!-- 모달 내용 (스크롤 영역 - flex 직접 자식) -->
+            <div id="hostSpacesScrollArea" class="flex-1 min-h-0 p-lg overflow-y-auto relative">
                 <!-- 로딩 상태 -->
                 <div id="hostSpacesLoading" class="flex flex-col items-center justify-center py-2xl text-text-secondary" style="display: none;">
                     <div class="w-10 h-10 border-3 border-border-color border-t-primary rounded-full animate-spin"></div>
@@ -288,12 +288,19 @@
                 </div>
 
                 <!-- 스페이스 목록 (JavaScript로 동적 렌더링) -->
-                <div id="hostSpacesContent" class="divide-y divide-border-color" style="display: none;">
+                <div id="hostSpacesContent" style="display: none;">
                 </div>
             </div>
 
+            <!-- 스크롤 하단 페이드 인디케이터 (스크롤 영역 바로 아래, 푸터 위에 겹침) -->
+            <div id="hostSpacesScrollFade"
+                 class="h-12 -mt-12 pointer-events-none relative z-10 transition-opacity duration-200"
+                 style="background: linear-gradient(to top, rgba(255,255,255,0.95), transparent); display: none;">
+            </div>
+
             <!-- 모달 푸터 -->
-            <div class="p-lg border-t border-border-color flex justify-end">
+            <div class="p-lg border-t border-border-color flex items-center justify-between">
+                <span id="hostSpacesCountInfo" class="text-xs text-text-muted"></span>
                 <button id="closeHostSpacesFooterBtn"
                         class="min-h-[44px] px-lg py-2.5 text-sm font-medium text-text-secondary
                                bg-surface border border-border-color rounded-lg

--- a/src/main/resources/templates/admin/hosts/list.html
+++ b/src/main/resources/templates/admin/hosts/list.html
@@ -104,6 +104,30 @@
                 width: 30px;
             }
         }
+
+        /* JS 연동 클래스: Modal */
+        .modal-overlay {
+            opacity: 0;
+            visibility: hidden;
+            backdrop-filter: blur(0px);
+            transition: opacity 0.3s ease, visibility 0.3s ease, backdrop-filter 0.3s ease;
+        }
+        .modal-overlay.show {
+            opacity: 1;
+            visibility: visible;
+            backdrop-filter: blur(4px);
+        }
+        .modal-container {
+            transform: translateY(20px) scale(0.95);
+            transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        }
+        .modal-overlay.show .modal-container {
+            transform: translateY(0) scale(1);
+        }
+        /* Body scroll lock */
+        body.modal-open {
+            overflow: hidden;
+        }
     </style>
 </head>
 <body class="bg-bg-color min-h-screen flex flex-col font-sans">
@@ -225,6 +249,62 @@
 
     <!-- Footer (Fragment 사용) -->
     <footer th:replace="~{admin/layout/fragments :: footer}"></footer>
+
+    <!--
+        호스트 스페이스 목록 모달
+        - 기본적으로 숨김 상태 (display: none)
+        - 호스트의 스페이스 개수 클릭 시 표시
+        - ESC 키 또는 오버레이 클릭 시 닫힘
+        - 모달이 열렸을 때 body의 스크롤 방지
+    -->
+    <div id="hostSpacesModal"
+         class="modal-overlay fixed inset-0 bg-black/60 flex justify-center items-center z-[10000]"
+         style="display: none;"
+         role="dialog" aria-labelledby="hostSpacesModalTitle" aria-modal="true">
+        <div class="modal-container bg-surface rounded-xl shadow-xl max-w-[600px] w-[90%] max-h-[85vh] flex flex-col">
+            <!-- 모달 헤더 -->
+            <div class="flex justify-between items-center p-lg border-b border-border-color">
+                <h3 id="hostSpacesModalTitle" class="text-xl font-bold text-text-primary m-0">스페이스 목록</h3>
+                <button id="closeHostSpacesModalBtn"
+                        class="w-11 h-11 flex items-center justify-center text-2xl text-text-secondary bg-transparent border-none rounded-lg cursor-pointer
+                               hover:bg-bg-color hover:text-text-primary transition-all duration-200"
+                        aria-label="모달 닫기">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+
+            <!-- 모달 내용 -->
+            <div class="p-lg overflow-y-auto flex-1">
+                <!-- 로딩 상태 -->
+                <div id="hostSpacesLoading" class="flex flex-col items-center justify-center py-2xl text-text-secondary" style="display: none;">
+                    <div class="w-10 h-10 border-3 border-border-color border-t-primary rounded-full animate-spin"></div>
+                    <p class="mt-md text-sm">스페이스 목록 로딩 중...</p>
+                </div>
+
+                <!-- 에러 상태 -->
+                <div id="hostSpacesError"
+                     class="p-md bg-red-50 border border-red-200 rounded-lg text-danger text-sm text-center"
+                     style="display: none;">
+                </div>
+
+                <!-- 스페이스 목록 (JavaScript로 동적 렌더링) -->
+                <div id="hostSpacesContent" class="divide-y divide-border-color" style="display: none;">
+                </div>
+            </div>
+
+            <!-- 모달 푸터 -->
+            <div class="p-lg border-t border-border-color flex justify-end">
+                <button id="closeHostSpacesFooterBtn"
+                        class="min-h-[44px] px-lg py-2.5 text-sm font-medium text-text-secondary
+                               bg-surface border border-border-color rounded-lg
+                               hover:bg-bg-color hover:text-text-primary
+                               active:scale-[0.98] transition-all duration-200 cursor-pointer
+                               focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2">
+                    닫기
+                </button>
+            </div>
+        </div>
+    </div>
 
     <!--
         Toast Notification

--- a/src/main/resources/templates/admin/hosts/list.html
+++ b/src/main/resources/templates/admin/hosts/list.html
@@ -128,6 +128,30 @@
         body.modal-open {
             overflow: hidden;
         }
+
+        /* 모달 내부 슬라이드 전환 */
+        #modalPanelContainer {
+            transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+        }
+
+        /* 스페이스 카드 클릭 가능 상태 */
+        .space-card-clickable {
+            cursor: pointer;
+        }
+        .space-card-clickable:hover {
+            border-color: #A3A3A3;
+            box-shadow: 0 2px 4px rgba(0,0,0,0.05);
+        }
+        .space-card-clickable:active {
+            transform: scale(0.99);
+        }
+        .space-card-clickable:focus-visible {
+            outline: 2px solid #171717;
+            outline-offset: 2px;
+        }
+        .space-card-clickable:focus:not(:focus-visible) {
+            outline: none;
+        }
     </style>
 </head>
 <body class="bg-bg-color min-h-screen flex flex-col font-sans">
@@ -264,7 +288,18 @@
         <div class="modal-container bg-surface rounded-xl shadow-xl max-w-[960px] w-[90%] max-h-[85vh] flex flex-col">
             <!-- 모달 헤더 -->
             <div class="flex justify-between items-center p-lg border-b border-border-color">
-                <h3 id="hostSpacesModalTitle" class="text-xl font-bold text-text-primary m-0">스페이스 목록</h3>
+                <div class="flex items-center gap-sm">
+                    <button id="backToSpaceListBtn"
+                            class="w-9 h-9 flex items-center justify-center text-text-secondary bg-transparent border-none rounded-lg cursor-pointer
+                                   hover:bg-bg-color hover:text-text-primary transition-all duration-200"
+                            style="display: none;"
+                            aria-label="스페이스 목록으로 돌아가기">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/>
+                        </svg>
+                    </button>
+                    <h3 id="hostSpacesModalTitle" class="text-xl font-bold text-text-primary m-0">스페이스 목록</h3>
+                </div>
                 <button id="closeHostSpacesModalBtn"
                         class="w-11 h-11 flex items-center justify-center text-2xl text-text-secondary bg-transparent border-none rounded-lg cursor-pointer
                                hover:bg-bg-color hover:text-text-primary transition-all duration-200"
@@ -273,22 +308,87 @@
                 </button>
             </div>
 
-            <!-- 모달 내용 (스크롤 영역 - flex 직접 자식) -->
-            <div id="hostSpacesScrollArea" class="flex-1 min-h-0 p-lg overflow-y-auto relative">
-                <!-- 로딩 상태 -->
-                <div id="hostSpacesLoading" class="flex flex-col items-center justify-center py-2xl text-text-secondary" style="display: none;">
-                    <div class="w-10 h-10 border-3 border-border-color border-t-primary rounded-full animate-spin"></div>
-                    <p class="mt-md text-sm">스페이스 목록 로딩 중...</p>
-                </div>
+            <!-- 모달 내용 (슬라이드 래퍼) -->
+            <div id="modalSlideWrapper" class="flex-1 min-h-0 overflow-hidden relative">
+                <div id="modalPanelContainer" class="flex w-[200%] h-full"
+                     style="transform: translateX(0%);">
 
-                <!-- 에러 상태 -->
-                <div id="hostSpacesError"
-                     class="p-md bg-red-50 border border-red-200 rounded-lg text-danger text-sm text-center"
-                     style="display: none;">
-                </div>
+                    <!-- [패널 1: 스페이스 목록] - 기존 콘텐츠 유지 -->
+                    <div class="w-1/2 h-full overflow-y-auto relative p-lg" id="hostSpacesScrollArea">
+                        <!-- 로딩 상태 -->
+                        <div id="hostSpacesLoading" class="flex flex-col items-center justify-center py-2xl text-text-secondary" style="display: none;">
+                            <div class="w-10 h-10 border-3 border-border-color border-t-primary rounded-full animate-spin"></div>
+                            <p class="mt-md text-sm">스페이스 목록 로딩 중...</p>
+                        </div>
 
-                <!-- 스페이스 목록 (JavaScript로 동적 렌더링) -->
-                <div id="hostSpacesContent" style="display: none;">
+                        <!-- 에러 상태 -->
+                        <div id="hostSpacesError"
+                             class="p-md bg-red-50 border border-red-200 rounded-lg text-danger text-sm text-center"
+                             style="display: none;">
+                        </div>
+
+                        <!-- 스페이스 목록 (JavaScript로 동적 렌더링) -->
+                        <div id="hostSpacesContent" style="display: none;">
+                        </div>
+                    </div>
+
+                    <!-- [패널 2: 스페이스 상세] - 신규 -->
+                    <div class="w-1/2 h-full overflow-y-auto p-lg" id="spaceDetailPanel">
+                        <!-- 로딩 상태 -->
+                        <div id="spaceDetailLoading" class="flex flex-col items-center justify-center py-2xl text-text-secondary" style="display: none;">
+                            <div class="w-10 h-10 border-3 border-border-color border-t-primary rounded-full animate-spin"></div>
+                            <p class="mt-md text-sm">스페이스 정보 로딩 중...</p>
+                        </div>
+
+                        <!-- 에러 상태 -->
+                        <div id="spaceDetailError"
+                             class="p-md bg-red-50 border border-red-200 rounded-lg text-danger text-sm text-center"
+                             style="display: none;">
+                        </div>
+
+                        <!-- 상세 콘텐츠 -->
+                        <div id="spaceDetailContent" style="display: none;">
+                            <dl class="grid grid-cols-[auto_1fr] gap-x-10 gap-y-5 items-baseline">
+                                <!-- 스페이스 ID -->
+                                <dt class="text-sm text-text-secondary font-medium whitespace-nowrap">스페이스 ID</dt>
+                                <dd id="detailSpaceId" class="text-base text-text-primary font-mono m-0">-</dd>
+
+                                <!-- 스페이스 코드 -->
+                                <dt class="text-sm text-text-secondary font-medium whitespace-nowrap">스페이스 코드</dt>
+                                <dd id="detailSpaceCode" class="text-base text-text-primary font-mono m-0">-</dd>
+
+                                <!-- 스페이스 이름 -->
+                                <dt class="text-sm text-text-secondary font-medium whitespace-nowrap">스페이스 이름</dt>
+                                <dd id="detailSpaceName" class="text-base text-text-primary font-semibold m-0">-</dd>
+
+                                <!-- 공개 여부 -->
+                                <dt class="text-sm text-text-secondary font-medium whitespace-nowrap">공개 여부</dt>
+                                <dd id="detailSpacePublic" class="text-base m-0">-</dd>
+
+                                <!-- 구분선 -->
+                                <div class="col-span-2 border-t border-border-color my-1"></div>
+
+                                <!-- 작품소개 개수 -->
+                                <dt class="text-sm text-text-secondary font-medium whitespace-nowrap">작품소개 개수</dt>
+                                <dd id="detailProductCount" class="text-base text-text-primary font-semibold m-0">-</dd>
+
+                                <!-- 방명록 개수 -->
+                                <dt class="text-sm text-text-secondary font-medium whitespace-nowrap">방명록 개수</dt>
+                                <dd id="detailGuestBookCount" class="text-base text-text-primary font-semibold m-0">-</dd>
+
+                                <!-- 구분선 -->
+                                <div class="col-span-2 border-t border-border-color my-1"></div>
+
+                                <!-- 생성일 -->
+                                <dt class="text-sm text-text-secondary font-medium whitespace-nowrap">생성일</dt>
+                                <dd id="detailCreatedAt" class="text-base text-text-primary m-0">-</dd>
+
+                                <!-- 수정일 -->
+                                <dt class="text-sm text-text-secondary font-medium whitespace-nowrap">수정일</dt>
+                                <dd id="detailUpdatedAt" class="text-base text-text-primary m-0">-</dd>
+                            </dl>
+                        </div>
+                    </div>
                 </div>
             </div>
 
@@ -301,14 +401,26 @@
             <!-- 모달 푸터 -->
             <div class="p-lg border-t border-border-color flex items-center justify-between">
                 <span id="hostSpacesCountInfo" class="text-xs text-text-muted"></span>
-                <button id="closeHostSpacesFooterBtn"
-                        class="min-h-[44px] px-lg py-2.5 text-sm font-medium text-text-secondary
-                               bg-surface border border-border-color rounded-lg
-                               hover:bg-bg-color hover:text-text-primary
-                               active:scale-[0.98] transition-all duration-200 cursor-pointer
-                               focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2">
-                    닫기
-                </button>
+                <div class="flex items-center gap-sm">
+                    <button id="hostModalVisitSpaceBtn"
+                            class="min-h-[44px] px-lg py-2.5 text-sm font-semibold text-white
+                                   bg-cta rounded-lg
+                                   hover:bg-cta-hover
+                                   active:scale-[0.98] transition-all duration-200 cursor-pointer
+                                   focus:outline-none focus:ring-2 focus:ring-cta focus:ring-offset-2"
+                            style="display: none;"
+                            aria-label="게스트 페이지로 이동">
+                        게스트 페이지로 이동
+                    </button>
+                    <button id="closeHostSpacesFooterBtn"
+                            class="min-h-[44px] px-lg py-2.5 text-sm font-medium text-text-secondary
+                                   bg-surface border border-border-color rounded-lg
+                                   hover:bg-bg-color hover:text-text-primary
+                                   active:scale-[0.98] transition-all duration-200 cursor-pointer
+                                   focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2">
+                        닫기
+                    </button>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/admin/hosts/list.html
+++ b/src/main/resources/templates/admin/hosts/list.html
@@ -285,7 +285,7 @@
          class="modal-overlay fixed inset-0 bg-black/60 flex justify-center items-center z-[10000]"
          style="display: none;"
          role="dialog" aria-labelledby="hostSpacesModalTitle" aria-modal="true">
-        <div class="modal-container bg-surface rounded-xl shadow-xl max-w-[960px] w-[90%] max-h-[85vh] flex flex-col">
+        <div class="modal-container bg-surface rounded-xl shadow-xl max-w-[960px] w-[90%] h-[85vh] flex flex-col">
             <!-- 모달 헤더 -->
             <div class="flex justify-between items-center p-lg border-b border-border-color">
                 <div class="flex items-center gap-sm">

--- a/src/test/java/com/forgather/acceptance/AdminHostAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/AdminHostAcceptanceTest.java
@@ -13,12 +13,19 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.forgather.back_office.auth.session.SessionManager;
 import com.forgather.back_office.dto.AdminHostResponse;
+import com.forgather.back_office.dto.HostSpacesResponse;
 import com.forgather.back_office.model.AdminSession;
 import com.forgather.back_office.model.AdminUser;
 import com.forgather.back_office.repository.AdminUserRepository;
+import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.HostRepository;
+import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.fixture.AdminUserFixture;
 import com.forgather.fixture.HostFixture;
+import com.forgather.fixture.SpaceFixture;
+import com.forgather.global.auth.model.Host;
+import com.forgather.global.auth.model.SpaceHostMap;
+import com.forgather.global.auth.repository.SpaceHostMapRepository;
 
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 import io.restassured.module.mockmvc.specification.MockMvcRequestSpecification;
@@ -37,6 +44,12 @@ class AdminHostAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private HostRepository hostRepository;
+
+    @Autowired
+    private SpaceRepository spaceRepository;
+
+    @Autowired
+    private SpaceHostMapRepository spaceHostMapRepository;
 
     @Autowired
     private SessionManager sessionManager;
@@ -94,6 +107,51 @@ class AdminHostAcceptanceTest extends AcceptanceTest {
         var result = RestAssuredMockMvc.given()
             .when()
             .get("/admin/hosts")
+            .then()
+            .extract();
+
+        // then
+        assertThat(result.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @DisplayName("호스트가 소유한 스페이스 목록을 조회한다.")
+    @Test
+    void getHostSpaces() {
+        // given
+        Host host = hostRepository.save(HostFixture.createHost());
+        Space space1 = spaceRepository.save(SpaceFixture.createSpaceWithCode("1111111111"));
+        Space space2 = spaceRepository.save(SpaceFixture.createSpaceWithCode("2222222222"));
+        spaceHostMapRepository.save(new SpaceHostMap(space1, host));
+        spaceHostMapRepository.save(new SpaceHostMap(space2, host));
+
+        // when
+        HostSpacesResponse result = givenWithSession()
+            .when()
+            .get("/admin/hosts/{hostId}/spaces", host.getId())
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract()
+            .body()
+            .as(HostSpacesResponse.class);
+
+        // then
+        assertAll(
+            () -> assertThat(result.hostId()).isEqualTo(host.getId()),
+            () -> assertThat(result.hostName()).isEqualTo(host.getName()),
+            () -> assertThat(result.spaces()).hasSize(2)
+        );
+    }
+
+    @DisplayName("세션이 없으면 호스트의 스페이스 목록을 조회할 수 없다.")
+    @Test
+    void getHostSpacesWithoutSession() {
+        // given
+        Host host = hostRepository.save(HostFixture.createHost());
+
+        // when
+        var result = RestAssuredMockMvc.given()
+            .when()
+            .get("/admin/hosts/{hostId}/spaces", host.getId())
             .then()
             .extract();
 

--- a/src/test/java/com/forgather/back_office/service/AdminHostServiceTest.java
+++ b/src/test/java/com/forgather/back_office/service/AdminHostServiceTest.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.forgather.back_office.dto.AdminHostResponse;
 import com.forgather.back_office.dto.HostSpacesResponse;
+import com.forgather.back_office.dto.SimpleSpaceResponse;
 import com.forgather.back_office.repository.AdminUserRepository;
 import com.forgather.container.TestOnContainer;
 import com.forgather.domain.space.model.Space;
@@ -77,8 +78,8 @@ class AdminHostServiceTest extends TestOnContainer {
     void getHostSpaces() {
         // given
         Host host = hostRepository.save(HostFixture.createHost());
-        Space space1 = spaceRepository.save(SpaceFixture.createSpaceWithCode("1111111111"));
-        Space space2 = spaceRepository.save(SpaceFixture.createSpaceWithCode("2222222222"));
+        Space space1 = spaceRepository.save(SpaceFixture.createSpaceWithCodeAndName("1111111111", "첫번째 스페이스"));
+        Space space2 = spaceRepository.save(SpaceFixture.createSpaceWithCodeAndName("2222222222", "두번째 스페이스"));
         spaceHostMapRepository.save(new SpaceHostMap(space1, host));
         spaceHostMapRepository.save(new SpaceHostMap(space2, host));
 
@@ -89,7 +90,11 @@ class AdminHostServiceTest extends TestOnContainer {
         assertAll(
             () -> assertThat(result.hostId()).isEqualTo(host.getId()),
             () -> assertThat(result.hostName()).isEqualTo(host.getName()),
-            () -> assertThat(result.spaces()).hasSize(2)
+            () -> assertThat(result.spaces()).hasSize(2),
+            () -> assertThat(result.spaces()).extracting(SimpleSpaceResponse::code)
+                .containsExactlyInAnyOrder("1111111111", "2222222222"),
+            () -> assertThat(result.spaces()).extracting(SimpleSpaceResponse::name)
+                .containsExactlyInAnyOrder("첫번째 스페이스", "두번째 스페이스")
         );
     }
 

--- a/src/test/java/com/forgather/back_office/service/AdminHostServiceTest.java
+++ b/src/test/java/com/forgather/back_office/service/AdminHostServiceTest.java
@@ -67,8 +67,8 @@ class AdminHostServiceTest extends TestOnContainer {
             () -> assertThat(result.pageSize()).isEqualTo(10),
             () -> assertThat(result.totalCount()).isEqualTo(2),
             () -> assertThat(result.totalPages()).isEqualTo(1),
-            () -> assertThat(result.hosts().get(0).spaceIds()).hasSize(2),
-            () -> assertThat(result.hosts().get(1).spaceIds()).hasSize(0)
+            () -> assertThat(result.hosts().get(0).spaceCount()).isEqualTo(2L),
+            () -> assertThat(result.hosts().get(1).spaceCount()).isEqualTo(0L)
         );
     }
 

--- a/src/test/java/com/forgather/back_office/service/AdminHostServiceTest.java
+++ b/src/test/java/com/forgather/back_office/service/AdminHostServiceTest.java
@@ -12,9 +12,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.forgather.container.TestOnContainer;
 import com.forgather.back_office.dto.AdminHostResponse;
+import com.forgather.back_office.dto.HostSpacesResponse;
 import com.forgather.back_office.repository.AdminUserRepository;
+import com.forgather.container.TestOnContainer;
 import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.HostRepository;
 import com.forgather.domain.space.repository.SpaceRepository;
@@ -68,6 +69,44 @@ class AdminHostServiceTest extends TestOnContainer {
             () -> assertThat(result.totalPages()).isEqualTo(1),
             () -> assertThat(result.hosts().get(0).spaceIds()).hasSize(2),
             () -> assertThat(result.hosts().get(1).spaceIds()).hasSize(0)
+        );
+    }
+
+    @DisplayName("호스트가 소유한 스페이스 목록을 조회한다.")
+    @Test
+    void getHostSpaces() {
+        // given
+        Host host = hostRepository.save(HostFixture.createHost());
+        Space space1 = spaceRepository.save(SpaceFixture.createSpaceWithCode("1111111111"));
+        Space space2 = spaceRepository.save(SpaceFixture.createSpaceWithCode("2222222222"));
+        spaceHostMapRepository.save(new SpaceHostMap(space1, host));
+        spaceHostMapRepository.save(new SpaceHostMap(space2, host));
+
+        // when
+        HostSpacesResponse result = adminHostService.getHostSpaces(host.getId());
+
+        // then
+        assertAll(
+            () -> assertThat(result.hostId()).isEqualTo(host.getId()),
+            () -> assertThat(result.hostName()).isEqualTo(host.getName()),
+            () -> assertThat(result.spaces()).hasSize(2)
+        );
+    }
+
+    @DisplayName("스페이스가 없는 호스트의 스페이스 목록을 조회하면 빈 목록을 반환한다.")
+    @Test
+    void getHostSpacesWithNoSpaces() {
+        // given
+        Host host = hostRepository.save(HostFixture.createHost());
+
+        // when
+        HostSpacesResponse result = adminHostService.getHostSpaces(host.getId());
+
+        // then
+        assertAll(
+            () -> assertThat(result.hostId()).isEqualTo(host.getId()),
+            () -> assertThat(result.hostName()).isEqualTo(host.getName()),
+            () -> assertThat(result.spaces()).isEmpty()
         );
     }
 }

--- a/src/test/java/com/forgather/back_office/service/AdminHostServiceTest.java
+++ b/src/test/java/com/forgather/back_office/service/AdminHostServiceTest.java
@@ -1,6 +1,7 @@
 package com.forgather.back_office.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.DisplayName;
@@ -25,6 +26,7 @@ import com.forgather.fixture.SpaceFixture;
 import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.model.SpaceHostMap;
 import com.forgather.global.auth.repository.SpaceHostMapRepository;
+import com.forgather.global.exception.NotFoundException;
 
 @Transactional
 @ActiveProfiles("test")
@@ -113,5 +115,16 @@ class AdminHostServiceTest extends TestOnContainer {
             () -> assertThat(result.hostName()).isEqualTo(host.getName()),
             () -> assertThat(result.spaces()).isEmpty()
         );
+    }
+
+    @DisplayName("존재하지 않는 호스트의 스페이스 목록을 조회하면 예외가 발생한다.")
+    @Test
+    void getHostSpacesWithNonExistentHost() {
+        // given
+        Long nonExistentHostId = 9999L;
+
+        // when & then
+        assertThatThrownBy(() -> adminHostService.getHostSpaces(nonExistentHostId))
+            .isInstanceOf(NotFoundException.class);
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- close #14 

## 작업 내용

- 해당 호스트의 전체 스페이스 목록 조회 API와 모달 UI 구현

<br>
<img width="943" height="477" alt="image" src="https://github.com/user-attachments/assets/b1825229-6242-44a8-af37-b2ca05c0788d" />

<img width="858" height="848" alt="image" src="https://github.com/user-attachments/assets/973648a0-117c-48d5-b66a-7c7c9ad7d45a" />
<br>

- 호스트의 전체 스페이스 목록에서 개별 상세 조회 모달 UI 구현
<img width="850" height="836" alt="image" src="https://github.com/user-attachments/assets/22d15136-3524-42c3-aa72-5c661a4d4499" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 관리자 대시보드에서 호스트의 스페이스를 모달로 조회·탐색 가능 (목록 ↔ 상세 전환, 로딩/오류 상태, 애니메이션, 스크롤 잠금)
  * 모달에서 스페이스 공개 여부, 코드, 생성일 등 상세 정보 표시 및 새 창 이동 지원, 키보드 접근성 개선

* **API 변경**
  * 호스트 응답에 스페이스 ID 배열 대신 스페이스 개수(spaceCount)를 제공하고, 호스트별 스페이스 조회 엔드포인트 추가

* **Tests**
  * 호스트 스페이스 조회 관련 단위·통합 테스트 추가 (인증/미인증 시나리오 포함)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->