### PR TITLE
fix: 빈 생성에 사용할 생성자 Autowired 어노테이션 추가

### DIFF
--- a/src/main/java/com/forgather/back_office/service/PrometheusSecurityMetricsService.java
+++ b/src/main/java/com/forgather/back_office/service/PrometheusSecurityMetricsService.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
@@ -45,6 +46,7 @@ public class PrometheusSecurityMetricsService implements SecurityMetricsService 
 
     private final RestClient restClient;
 
+    @Autowired
     public PrometheusSecurityMetricsService(MonitoringProperties properties) {
         this.restClient = RestClient.builder()
             .baseUrl(properties.prometheusUrl())


### PR DESCRIPTION
## 연관된 이슈

- close #20

## 작업 내용
- 생성자가 2개로 스프링 컨테이너가 빈 생성에 사용할 생성자를 선택하지 못해 발생한 에러 해결

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

이번 업데이트는 내부 구조 개선에 해당하며, 사용자가 직접 체감할 수 있는 새로운 기능이나 변경사항은 없습니다.

* **개선 사항**
  * 내부 의존성 주입 메커니즘을 최적화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->