### PR TITLE
refactor: swagger 스키마 추가

### DIFF
--- a/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
+++ b/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
@@ -48,11 +48,13 @@ public class GuestBookController {
             @Parameter(
                 name = "page",
                 description = "페이지 번호 (1부터 시작)",
+                schema = @Schema(type = "integer", minimum = "1"),
                 example = "1"
             ),
             @Parameter(
                 name = "size",
                 description = "페이지 크기",
+                schema = @Schema(type = "integer"),
                 example = "15"
             ),
             @Parameter(
@@ -61,6 +63,8 @@ public class GuestBookController {
                 example = "createdAt,desc",
                 array = @ArraySchema(schema = @Schema(type = "string"))
             )
+            // 향후 페이지네이션 API가 추가되어 동일한 파라미터 정의가 반복될 경우,
+            // @Parameters 메타 어노테이션을 활용한 @PageableParameters 커스텀 어노테이션으로 중복을 제거할 수 있다.
         }
     )
     @GetMapping

--- a/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
+++ b/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
@@ -63,8 +63,6 @@ public class GuestBookController {
                 example = "createdAt,desc",
                 array = @ArraySchema(schema = @Schema(type = "string"))
             )
-            // 향후 페이지네이션 API가 추가되어 동일한 파라미터 정의가 반복될 경우,
-            // @Parameters 메타 어노테이션을 활용한 @PageableParameters 커스텀 어노테이션으로 중복을 제거할 수 있다.
         }
     )
     @GetMapping

--- a/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
+++ b/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
@@ -54,7 +54,7 @@ public class GuestBookController {
             @Parameter(
                 name = "size",
                 description = "페이지 크기",
-                schema = @Schema(type = "integer"),
+                schema = @Schema(type = "integer", minimum = "1"),
                 example = "15"
             ),
             @Parameter(

--- a/src/main/java/com/forgather/domain/product/dto/ProductPhotoResponse.java
+++ b/src/main/java/com/forgather/domain/product/dto/ProductPhotoResponse.java
@@ -2,10 +2,19 @@ package com.forgather.domain.product.dto;
 
 import com.forgather.domain.product.model.ProductPhoto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record ProductPhotoResponse(
+    @Schema(description = "사진 id", example = "1")
     Long id,
+
+    @Schema(description = "원본 파일명", example = "chair1.jpg")
     String originalName,
+
+    @Schema(description = "S3 파일 경로", example = "forgather/v2/spaces/1234567890/product/abc.jpg")
     String path,
+
+    @Schema(description = "사진 정렬 순서", example = "1")
     int order
 ) {
 

--- a/src/main/java/com/forgather/domain/product/dto/ProductsResponse.java
+++ b/src/main/java/com/forgather/domain/product/dto/ProductsResponse.java
@@ -3,7 +3,14 @@ package com.forgather.domain.product.dto;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record ProductsResponse(
+    @ArraySchema(
+        schema = @Schema(implementation = SimpleProductResponse.class),
+        arraySchema = @Schema(description = "작품 목록")
+    )
     List<SimpleProductResponse> products
 ) {
 

--- a/src/main/java/com/forgather/domain/product/dto/SimpleProductResponse.java
+++ b/src/main/java/com/forgather/domain/product/dto/SimpleProductResponse.java
@@ -3,11 +3,22 @@ package com.forgather.domain.product.dto;
 import com.forgather.domain.product.model.Product;
 import com.forgather.domain.product.model.ProductPhoto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record SimpleProductResponse(
+    @Schema(description = "작품 id", example = "1")
     Long id,
+
+    @Schema(description = "작품명", example = "고귀한 의자")
     String title,
+
+    @Schema(description = "작품 카테고리", example = "Chair")
     String category,
+
+    @Schema(description = "임베드 영상 링크", example = "https://youtu.be/lkuAxAVgAX0")
     String videoUrl,
+
+    @Schema(description = "첫 번째 사진 정보 (없으면 null)")
     ProductPhotoResponse firstPhoto
 ) {
 

--- a/src/main/java/com/forgather/domain/stats/dto/LandingStatsResponse.java
+++ b/src/main/java/com/forgather/domain/stats/dto/LandingStatsResponse.java
@@ -1,6 +1,14 @@
 package com.forgather.domain.stats.dto;
 
-public record LandingStatsResponse(LandingSpaceStats spaceStats, LandingGuestBookStats guestBookStats) {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record LandingStatsResponse(
+    @Schema(description = "스페이스 통계")
+    LandingSpaceStats spaceStats,
+
+    @Schema(description = "방명록 통계")
+    LandingGuestBookStats guestBookStats
+) {
 
     public LandingStatsResponse(long spaceCount, long guestBookCardCount) {
         this(
@@ -9,9 +17,15 @@ public record LandingStatsResponse(LandingSpaceStats spaceStats, LandingGuestBoo
         );
     }
 
-    public record LandingSpaceStats(long spaceCount) {
+    public record LandingSpaceStats(
+        @Schema(description = "총 스페이스 수", example = "42")
+        long spaceCount
+    ) {
     }
 
-    public record LandingGuestBookStats(long cardCount) {
+    public record LandingGuestBookStats(
+        @Schema(description = "총 방명록 카드 수", example = "1024")
+        long cardCount
+    ) {
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- close #22 

## 작업 내용
### swagger 스키마 추가 요청
프론트 팀원으로부터 다음과 같은 요청이 왔습니다.

<img width="980" height="409" alt="Image" src="https://github.com/user-attachments/assets/08959698-cc27-4040-84c7-7606b33000b5" />

orval은 스웨거를 기반으로 클라이언트 typescript 타입 관리를 자동화해주는 라이브러리입니다.
이를 활용하면 클라이언트 개발의 간편함과 정확성이 향상될 것으로 보입니다.
[참고](https://junhyunny.github.io/openapi/orval/auto-generate-code/react-query/msw/open-api-spec-with-orval/)

schema는 parameter의 내용(유형, 설명, 타입, 예시 등)을 설명할 때 사용되며, orval 작동에 있어 핵심적인 정보입니다.
따라서 더 세밀한 문서화 및 클라이언트 개발 편의 향상을 위해 누락된 schema를 보완하는 작업을 진행했습니다.
[swagger docs](https://swagger.io/docs/specification/v3_0/describing-parameters/#required-and-optional-parameters)

### 추가 대상
- GuestBookController의 방명록 조회 api
- stats 관련 dto
- product 관련 dto

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * OpenAPI/스웨거 스키마 설명이 전반적으로 강화되었습니다.
  * 게스트북 조회의 페이지 매개변수에 정수 타입 및 최소값(min=1) 제약이 명시되었습니다.
  * 상품 응답의 사진 및 요약 필드에 설명과 예시가 추가되었습니다.
  * 랜딩 통계 응답의 필드 설명과 예시가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->