### PR TITLE
fix(deploy): 디렉토리 권한 문제 해결 및 배포 로그 관측성 개선

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -2,9 +2,10 @@
 
 JAR_NAME="forgather-0.0.1-SNAPSHOT.jar"
 PORT=8080
-LOG_DIR="/home/ubuntu/forgather-backend/logs"
-JAR_PATH="/home/ubuntu/forgather-backend/$JAR_NAME"
-LOG_FILE="$LOG_DIR/app.log"
+APP_DIR="/home/ubuntu/forgather-backend"
+LOG_DIR="$APP_DIR/logs"
+JAR_PATH="$APP_DIR/$JAR_NAME"
+NOHUP_LOG="$LOG_DIR/nohup.log"
 
 echo "🛑 기존 $PORT 포트 프로세스 종료 시도..."
 PID=$(sudo lsof -t -i:$PORT)
@@ -17,14 +18,28 @@ else
   echo "ℹ️  $PORT 포트에 실행 중인 프로세스 없음"
 fi
 
-echo "🔐 jar 실행 권한 및 소유자 변경..."
-sudo chown ubuntu:ubuntu "$JAR_PATH"
+echo "🔐 디렉토리 및 파일 소유자 변경..."
+sudo chown -R ubuntu:ubuntu "$APP_DIR"
 sudo chmod 744 "$JAR_PATH"
 
 echo "📁 로그 디렉토리 생성..."
 sudo -u ubuntu mkdir -p "$LOG_DIR"
 
 echo "🚀 ubuntu 사용자로 애플리케이션 실행 (포트: $PORT)..."
-sudo -u ubuntu nohup java -jar "$JAR_PATH" --server.port=$PORT 1> /dev/null 2>&1 &
+sudo -u ubuntu nohup java -jar "$JAR_PATH" --server.port=$PORT >> "$NOHUP_LOG" 2>&1 &
 
-echo "✅ 배포 완료. 로그: $LOG_FILE"
+echo "⏳ 10초 후 프로세스 실행 확인..."
+sleep 10
+
+if pgrep -f "$JAR_NAME" > /dev/null; then
+  echo "✅ 애플리케이션 프로세스 실행 확인"
+  echo "📝 stdout 로그: $NOHUP_LOG"
+  echo "📝 애플리케이션 로그: $LOG_DIR/app.log (logback)"
+else
+  echo "❌ 애플리케이션 프로세스 실행 실패"
+  echo "📋 stdout 로그 마지막 50줄:"
+  sudo tail -50 "$NOHUP_LOG" 2>/dev/null || echo "(로그 파일 없음)"
+  exit 1
+fi
+
+echo "✅ 배포 완료"


### PR DESCRIPTION
## 연관된 이슈

- close #31 

## 작업 내용

CodeDeploy가 루트 권한으로 생성한 디렉토리에 ubuntu 사용자가
하위 디렉토리를 생성하지 못해 배포가 조용히 실패하는 문제 수정

- chown 대상을 jar 파일에서 APP_DIR 전체로 변경하여
  CodeDeploy가 root로 생성한 디렉토리의 소유권을 ubuntu로 이전
- nohup stdout/stderr을 파일에 저장하여 부팅 실패 시 디버깅 가능
- Java 프로세스 실행 여부를 pgrep으로 검증 후 실패 시 exit 1로
  CodeDeploy에 실패를 전파하여 자동 롤백 활성화

배경: 새 인스턴스에서 첫 배포 시 mkdir logs 가 Permission denied
      로 실패했으나, nohup 백그라운드 실행과 로그 리다이렉션이
      /dev/null 이어서 실패 원인 파악에 시간이 오래 걸림

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* **배포 및 운영**
  * 배포 완료 후 자동으로 애플리케이션 프로세스 실행 상태를 검증합니다.
  * 배포 실패 시 진단에 필요한 로그 정보를 자동으로 출력하여 문제 해결을 가속화합니다.
  * 애플리케이션 로그 기록 체계를 개선하여 모니터링 및 분석이 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->