### PR TITLE
refactor: 방명록 테이블에 nickname 필드 추가 및 저장 로직 수정

### DIFF
--- a/src/main/java/com/forgather/domain/guestbook/model/GuestBookCard.java
+++ b/src/main/java/com/forgather/domain/guestbook/model/GuestBookCard.java
@@ -47,23 +47,38 @@ public class GuestBookCard extends SoftDeleteEntity {
     private boolean isRead;
 
     public GuestBookCard(Space space, Guest guest, String message) {
-        validateRequiredFields(space, guest, message);
+        validateRequiredFields(space, guest, guest.getNickname(), message);
+        validateNickname(guest.getNickname());
         validateMessage(message);
         this.space = space;
         this.guest = guest;
+        this.nickname = guest.getNickname();
         this.message = message;
         this.isRead = false;
     }
 
-    private void validateRequiredFields(Space space, Guest guest, String message) {
+    private void validateRequiredFields(Space space, Guest guest, String nickname, String message) {
         if (space == null) {
             throw new BaseNullPointerException("방명록 카드 스페이스는 null일 수 없습니다.");
         }
         if (guest == null) {
             throw new BaseNullPointerException("방명록 카드 방문자는 null일 수 없습니다.");
         }
+        if (nickname == null) {
+            throw new BaseNullPointerException("방명록 카드 방문자는 null일 수 없습니다.");
+        }
         if (message == null) {
             throw new BaseNullPointerException("방명록 카드 메세지는 null일 수 없습니다.", HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    private void validateNickname(String nickname) {
+        if (nickname.isBlank()) {
+            throw new BaseException("방문자 닉네임은 공백만 입력할 수 없습니다.");
+        }
+        int length = TextLengthCounter.count(nickname);
+        if (length > 10) {
+            throw new BaseException("방문자 닉네임은 최대 10자까지 입력 가능합니다. nickname.length: " + length);
         }
     }
 

--- a/src/main/java/com/forgather/domain/guestbook/model/GuestBookCard.java
+++ b/src/main/java/com/forgather/domain/guestbook/model/GuestBookCard.java
@@ -65,7 +65,7 @@ public class GuestBookCard extends SoftDeleteEntity {
             throw new BaseNullPointerException("방명록 카드 방문자는 null일 수 없습니다.");
         }
         if (nickname == null) {
-            throw new BaseNullPointerException("방명록 카드 방문자는 null일 수 없습니다.");
+            throw new BaseNullPointerException("방문자 닉네임은 null일 수 없습니다.");
         }
         if (message == null) {
             throw new BaseNullPointerException("방명록 카드 메세지는 null일 수 없습니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/forgather/domain/guestbook/model/GuestBookCard.java
+++ b/src/main/java/com/forgather/domain/guestbook/model/GuestBookCard.java
@@ -36,8 +36,8 @@ public class GuestBookCard extends SoftDeleteEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "guest_id", nullable = false)
     private Guest guest;
-
-    @Column(name = "nickname", length = 10, nullable = false)
+    
+    @Column(name = "nickname", length = 10, nullable = true)
     private String nickname;
 
     @Column(name = "message", length = 500, nullable = false)

--- a/src/main/java/com/forgather/domain/guestbook/model/GuestBookCard.java
+++ b/src/main/java/com/forgather/domain/guestbook/model/GuestBookCard.java
@@ -37,6 +37,9 @@ public class GuestBookCard extends SoftDeleteEntity {
     @JoinColumn(name = "guest_id", nullable = false)
     private Guest guest;
 
+    @Column(name = "nickname", length = 10, nullable = false)
+    private String nickname;
+
     @Column(name = "message", length = 500, nullable = false)
     private String message;
 

--- a/src/main/resources/db/migration/V11__add_guestbookcard_nickname.sql
+++ b/src/main/resources/db/migration/V11__add_guestbookcard_nickname.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `guest_book_card`
+    ADD COLUMN `nickname` VARCHAR(255) NULL;

--- a/src/test/java/com/forgather/domain/guestbook/model/GuestBookCardTest.java
+++ b/src/test/java/com/forgather/domain/guestbook/model/GuestBookCardTest.java
@@ -27,15 +27,6 @@ class GuestBookCardTest {
             .hasMessageContaining("방명록 카드 스페이스는 null일 수 없습니다.");
     }
 
-    @DisplayName("방문자가 null이면 예외를 던진다")
-    @Test
-    void throwExceptionWhenGuestIsNull() {
-        // when, then
-        assertThatThrownBy(() -> createGuestBookCardWithGuest(null))
-            .isInstanceOf(BaseNullPointerException.class)
-                .hasMessageContaining("방명록 카드 방문자는 null일 수 없습니다.");
-    }
-
     @DisplayName("메세지가 null이면 예외를 던진다")
     @Test
     void throwExceptionWhenMessageIsNull() {


### PR DESCRIPTION
## 연관된 이슈

- close #48

## 변경 사항
- `guest_book_card` 테이블에 `nickname` 컬럼 추가 (DB 변경)
- 방명록 작성 시 `GuestBookCard`에 닉네임 저장
- `GuestBookCard` 생성 시 닉네임 유효성 검사 추가

## 작업 내용

### Guest 테이블 제거를 위한 무중단 스키마 마이그레이션 (1단계)

`Guest` 테이블을 제거하고 닉네임을 `GuestBookCard` 테이블로 통합하는 마이그레이션 작업입니다.
운영 환경의 무중단 스키마 변경을 위해 이번 PR에서는 1단계 작업을 진행합니다.

**[마이그레이션 단계]**
- **(현재) 1단계**: `GuestBookCard`에 `nickname` 컬럼 추가 및 방명록 작성 시 양쪽(`Guest`, `GuestBookCard`) 모두에 닉네임 저장
- **(예정) 2단계**: 기존 데이터 백필(backfill) — `Guest.nickname` 값을 `GuestBookCard.nickname`으로 채움
- **(예정) 3단계**: `Guest` 테이블 참조 제거 및 닉네임 읽기 작업을 `GuestBookCard.nickname` 기준으로 변경

---

### Flyway 마이그레이션

기존 GuestBookCard의 `nickname`  부재를 고려해 컬럼을 `NULL` 허용으로 추가합니다.
백필 완료 후 `NOT NULL` 제약 조건을 추가할 예정입니다.

```sql
ALTER TABLE `guest_book_card`
    ADD COLUMN `nickname` VARCHAR(255) NULL;
```

---

### GuestBookCard 닉네임 유효성 검사

방명록 작성 시 `Guest.nickname`을 `GuestBookCard.nickname`에 복사하며, 아래 유효성 검사를 수행합니다.

**[검사 규칙]**
- `null` 불가
- 공백만으로 구성된 닉네임 불가
- 최대 10자 (유니코드 문자 기준)

---

### 테스트

`throwExceptionWhenGuestIsNull` 테스트는 생성자에서 `guest.getNickname()` 호출이 null 체크보다 선행되어 기존 방식으로 검증이 불가능하며, 마이그레이션 완료 후 삭제될 테스트이므로 제거했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 방명록 카드에 방문자 별명 저장 기능이 추가되었습니다.
- 방명록 카드 작성 시 방문자의 별명이 자동으로 기록되며, 최대 10자까지 저장 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->