### PR TITLE
fix: 배포 중 nginx health check 에러 해결

### DIFF
--- a/deploy/scripts/validate_service.sh
+++ b/deploy/scripts/validate_service.sh
@@ -29,7 +29,7 @@ ELAPSED=0
 log "ValidateService" "nginx 트래픽 헬스체크 시작 (최대 ${NGINX_HEALTH_TIMEOUT}초)"
 
 while true; do
-  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 \
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 -L \
     "http://localhost/actuator/health" || echo "000")
 
   if [[ "$HTTP_CODE" == "200" ]]; then


### PR DESCRIPTION
## 연관된 이슈

- close #68

## 작업 내용
### nginx 헬스체크 수정
nginx에서 http -> https로 인한 301 응답을 응답하는데,
기존 헬스체크 curl 명령어는 리다이렉트를 따라가지 않아 status=301로 헬스체크에 실패하는 문제가 발생했습니다.
이를 해결하기 위해 curl 명령어에 -L 옵션을 붙여 리다이렉트를 따라가고 최종 200을 응답하도록 수정했습니다.

이 부분을 제외하면 다음과 같이 db 마이그레이션까지 성공한 것을 확인할 수 있습니다.
```
 4월 22 20:50:57 ip-10-0-0-139 forgather-blue[71486]: 2026-04-22 20:50:57.929 INFO  o.f.core.internal.command.DbValidate    Successfully validated 12 migrations (execution time 00:00.092s)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 서비스 배포 검증 중 헬스 체크가 HTTP 리다이렉트를 올바르게 처리하도록 개선되었습니다. 타임아웃 및 롤백 처리 등 기존 동작은 그대로 유지되며, 보다 안정적인 검증이 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->