### PR TITLE
fix: cd 과정 중 nginx 헬스체크 오류

### DIFF
--- a/deploy/scripts/validate_service.sh
+++ b/deploy/scripts/validate_service.sh
@@ -29,7 +29,7 @@ ELAPSED=0
 log "ValidateService" "nginx 트래픽 헬스체크 시작 (최대 ${NGINX_HEALTH_TIMEOUT}초)"
 
 while true; do
-  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 -L \
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 -L -k \
     "http://localhost/actuator/health" || echo "000")
 
   if [[ "$HTTP_CODE" == "200" ]]; then

--- a/deploy/scripts/validate_service.sh
+++ b/deploy/scripts/validate_service.sh
@@ -29,7 +29,7 @@ ELAPSED=0
 log "ValidateService" "nginx 트래픽 헬스체크 시작 (최대 ${NGINX_HEALTH_TIMEOUT}초)"
 
 while true; do
-  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 \
+  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 3 -L \
     "http://localhost/actuator/health" || echo "000")
 
   if [[ "$HTTP_CODE" == "200" ]]; then


### PR DESCRIPTION
## 연관된 이슈

- close #68

## 작업 내용
- nginx https 리다이렉트를 따라가도록 -L 옵션 추가
- 리다이렉트 시 `api.forgather.app` ssl 인증서와 `localhost` 도메인 불일치로 https 연결 실패하는 문제 발생. -k 옵션으로 인증서 체크 무효화