### PR TITLE
refactor: API 성공 응답 포맷 리팩터링

### DIFF
--- a/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
+++ b/src/main/java/com/forgather/domain/guestbook/controller/GuestBookController.java
@@ -1,6 +1,6 @@
 package com.forgather.domain.guestbook.controller;
 
-import static software.amazon.awssdk.http.HttpStatusCode.CREATED;
+import static org.springframework.http.HttpStatus.CREATED;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -22,6 +22,7 @@ import com.forgather.domain.guestbook.dto.WriteGuestBookCardResponse;
 import com.forgather.domain.guestbook.service.GuestBookService;
 import com.forgather.global.auth.annotation.LoginHost;
 import com.forgather.global.auth.model.Host;
+import com.forgather.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -66,7 +67,7 @@ public class GuestBookController {
         }
     )
     @GetMapping
-    public ResponseEntity<GuestBookResponse> readGuestBook(
+    public ResponseEntity<ApiResponse<GuestBookResponse>> readGuestBook(
         @PathVariable(value = "spaceCode") String spaceCode,
         @Parameter(hidden = true)
         @PageableDefault(size = 15, sort = {"createdAt", "id"}, direction = Sort.Direction.DESC)
@@ -74,29 +75,29 @@ public class GuestBookController {
         @LoginHost(required = false) Host host
     ) {
         GuestBookResponse response = guestBookService.read(host, spaceCode, pageable);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "방명록 카드 조회", description = "공개 스페이스가 아닌 경우 호스트만 조회 가능")
     @GetMapping("/{guestBookCardId}")
-    public ResponseEntity<GuestBookCardResponse> readCard(
+    public ResponseEntity<ApiResponse<GuestBookCardResponse>> readCard(
         @PathVariable(value = "spaceCode") String spaceCode,
         @PathVariable(value = "guestBookCardId") Long guestBookCardId,
         @LoginHost(required = false) Host host
     ) {
         GuestBookCardResponse response = guestBookService.readCard(host, spaceCode, guestBookCardId);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @Operation(summary = "방명록 카드 작성", description = "방문자 닉네임(10자), 메세지(400자)")
     @PostMapping
-    public ResponseEntity<WriteGuestBookCardResponse> writeCard(
+    public ResponseEntity<ApiResponse<WriteGuestBookCardResponse>> writeCard(
         @PathVariable(value = "spaceCode") String spaceCode,
         @RequestBody WriteGuestBookCardRequest request
     ) {
         var response = guestBookService.writeCard(spaceCode, request);
-        return ResponseEntity.status(CREATED).body(response);
+        return ResponseEntity.status(CREATED).body(ApiResponse.success(response));
     }
 
     @SecurityRequirement(name = "bearerAuth")

--- a/src/main/java/com/forgather/domain/guestbook/controller/GuestbookController.java
+++ b/src/main/java/com/forgather/domain/guestbook/controller/GuestbookController.java
@@ -12,6 +12,7 @@ import com.forgather.domain.guestbook.dto.ReportHistoryResponse;
 import com.forgather.domain.guestbook.service.GuestbookReportService;
 import com.forgather.global.auth.annotation.LoginHost;
 import com.forgather.global.auth.model.Host;
+import com.forgather.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -54,12 +55,12 @@ public class GuestbookController {
         }
     )
     @GetMapping("/me/reports")
-    public ResponseEntity<ReportHistoryResponse> retrieveReportHistory(
+    public ResponseEntity<ApiResponse<ReportHistoryResponse>> retrieveReportHistory(
         @LoginHost(required = true) Host loginUser,
         @PageableDefault(size = 15, sort = {"createdAt", "id"}, direction = Sort.Direction.DESC)
         Pageable pageable
     ) {
         var response = guestBookReportService.retrieveReportHistory(loginUser, pageable);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/forgather/domain/guestbook/controller/SpaceGuestbookController.java
+++ b/src/main/java/com/forgather/domain/guestbook/controller/SpaceGuestbookController.java
@@ -21,8 +21,8 @@ import com.forgather.domain.guestbook.dto.GuestBookCardResponse;
 import com.forgather.domain.guestbook.dto.GuestBookResponse;
 import com.forgather.domain.guestbook.dto.WriteGuestBookCardRequest;
 import com.forgather.domain.guestbook.dto.WriteGuestBookCardResponse;
-import com.forgather.domain.guestbook.service.GuestbookReportService;
 import com.forgather.domain.guestbook.service.GuestBookService;
+import com.forgather.domain.guestbook.service.GuestbookReportService;
 import com.forgather.global.auth.annotation.LoginHost;
 import com.forgather.global.auth.model.Host;
 import com.forgather.global.response.ApiResponse;
@@ -120,14 +120,14 @@ public class SpaceGuestbookController {
     @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "방명록 신고", description = "호스트가 자신의 스페이스에 작성된 방명록을 신고한다. 신고 즉시 해당 방명록은 숨김 처리된다.")
     @PostMapping("/{guestBookCardId}/reports")
-    public ResponseEntity<CreateGuestBookReportResponse> report(
+    public ResponseEntity<ApiResponse<CreateGuestBookReportResponse>> report(
         @PathVariable(value = "spaceCode") String spaceCode,
         @PathVariable(value = "guestBookCardId") Long guestBookCardId,
         @LoginHost(required = true) Host host,
         @RequestBody @Valid CreateGuestBookReportRequest request
     ) {
         var response = guestBookReportService.report(host, spaceCode, guestBookCardId, request);
-        return ResponseEntity.status(CREATED).body(response);
+        return ResponseEntity.status(CREATED).body(ApiResponse.success(response));
     }
 
     @SecurityRequirement(name = "bearerAuth")

--- a/src/main/java/com/forgather/domain/product/controller/ProductController.java
+++ b/src/main/java/com/forgather/domain/product/controller/ProductController.java
@@ -19,6 +19,7 @@ import com.forgather.domain.product.dto.UpdateProductRequest;
 import com.forgather.domain.product.service.ProductService;
 import com.forgather.global.auth.annotation.LoginHost;
 import com.forgather.global.auth.model.Host;
+import com.forgather.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -37,45 +38,45 @@ public class ProductController {
 
     @Operation(summary = "작품 목록 조회", description = "작품 목록 조회가 반영된 api는 version 3으로 호출")
     @GetMapping(headers = "X-API-Version=3")
-    public ResponseEntity<ProductsResponse> getV3(@PathVariable(value = "spaceCode") String spaceCode) {
+    public ResponseEntity<ApiResponse<ProductsResponse>> getV3(@PathVariable(value = "spaceCode") String spaceCode) {
         var response = productService.getAll(spaceCode);
-        return ResponseEntity.ok().body(response);
+        return ResponseEntity.ok().body(ApiResponse.success(response));
     }
 
     @Operation(summary = "작품 상세 조회")
     @GetMapping(value = "/{productId}", headers = "X-API-Version=1")
-    public ResponseEntity<ProductResponse> get(
+    public ResponseEntity<ApiResponse<ProductResponse>> get(
         @PathVariable(value = "spaceCode") String spaceCode,
         @PathVariable(value = "productId") Long productId
     ) {
         var response = productService.get(spaceCode, productId);
-        return ResponseEntity.ok().body(response);
+        return ResponseEntity.ok().body(ApiResponse.success(response));
     }
 
     @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "작품 등록", description = "복수 작품 등록이 반영된 api는 version 3으로 호출")
     @PostMapping(headers = "X-API-Version=3")
-    public ResponseEntity<ProductResponse> registerV3(
+    public ResponseEntity<ApiResponse<ProductResponse>> registerV3(
         @PathVariable(value = "spaceCode") String spaceCode,
         @RequestBody RegisterProductRequest request,
         @LoginHost(required = true) Host host
     ) {
         var response = productService.register(host, spaceCode, request);
-        return ResponseEntity.status(CREATED).body(response);
+        return ResponseEntity.status(CREATED).body(ApiResponse.success(response));
     }
 
     @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "작품 수정",
         description = "변경 사항이 없는 데이터는 json에 포함하지 않거나 null로 요청한다.  복수 작품 등록이 반영된 api는 version 1로 호출")
     @PatchMapping(value = "/{productId}", headers = "X-API-Version=1")
-    public ResponseEntity<ProductResponse> updateV3(
+    public ResponseEntity<ApiResponse<ProductResponse>> updateV3(
         @PathVariable(value = "spaceCode") String spaceCode,
         @PathVariable(value = "productId") Long productId,
         @RequestBody UpdateProductRequest request,
         @LoginHost(required = true) Host host
     ) {
         var response = productService.update(host, spaceCode, productId, request);
-        return ResponseEntity.ok().body(response);
+        return ResponseEntity.ok().body(ApiResponse.success(response));
     }
 
     @SecurityRequirement(name = "bearerAuth")

--- a/src/main/java/com/forgather/domain/space/controller/SpaceController.java
+++ b/src/main/java/com/forgather/domain/space/controller/SpaceController.java
@@ -24,6 +24,7 @@ import com.forgather.domain.space.dto.UpdateSpaceRequest;
 import com.forgather.domain.space.service.SpaceService;
 import com.forgather.global.auth.annotation.LoginHost;
 import com.forgather.global.auth.model.Host;
+import com.forgather.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -44,7 +45,7 @@ public class SpaceController {
     @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "스페이스 생성", description = "새로운 스페이스를 생성합니다.")
     @SecurityRequirement(name = "bearerAuth")
-    public ResponseEntity<CreateSpaceResponse> create(
+    public ResponseEntity<ApiResponse<CreateSpaceResponse>> create(
         @Parameter(description = "스페이스 생성 정보 (JSON, text/plain)", required = true,
             content = @Content(schema = @Schema(implementation = CreateSpaceRequest.class)))
         @RequestPart("request") @Validated CreateSpaceRequest request,
@@ -52,14 +53,15 @@ public class SpaceController {
         @LoginHost Host host
     ) {
         var response = spaceService.create(request, file, host);
-        return ResponseEntity.status(CREATED).body(response);
+        return ResponseEntity.status(CREATED).body(ApiResponse.success(response));
     }
 
     @GetMapping("/{spaceCode}")
     @Operation(summary = "스페이스 조회", description = "스페이스 코드를 통해 스페이스 정보를 조회합니다.")
-    public ResponseEntity<SpaceResponse> getSpaceInformation(@PathVariable(name = "spaceCode") String spaceCode) {
+    public ResponseEntity<ApiResponse<SpaceResponse>> getSpaceInformation(
+        @PathVariable(name = "spaceCode") String spaceCode) {
         var response = spaceService.getSpaceInformation(spaceCode);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @DeleteMapping("/{spaceCode}")
@@ -75,7 +77,7 @@ public class SpaceController {
     @PatchMapping(value = "/{spaceCode}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "스페이스 정보 수정", description = "해당 스페이스 코드의 정보를 수정합니다.")
     @SecurityRequirement(name = "bearerAuth")
-    public ResponseEntity<SpaceResponse> update(
+    public ResponseEntity<ApiResponse<SpaceResponse>> update(
         @PathVariable(name = "spaceCode") String spaceCode,
         @Parameter(description = "스페이스 수정 정보 (JSON, text/plain)", required = true,
             content = @Content(schema = @Schema(implementation = UpdateSpaceRequest.class)))
@@ -84,25 +86,25 @@ public class SpaceController {
         @LoginHost Host host
     ) {
         var response = spaceService.update(spaceCode, request, file, host);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/me")
     @Operation(summary = "호스트의 스페이스 목록 조회", description = "로그인한 호스트의 스페이스 목록을 조회합니다.")
     @SecurityRequirement(name = "bearerAuth")
-    public ResponseEntity<HostSpaceResponse> getSpacesInformation(@LoginHost Host host) {
+    public ResponseEntity<ApiResponse<HostSpaceResponse>> getSpacesInformation(@LoginHost Host host) {
         var response = spaceService.getSpacesInformation(host);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/{spaceCode}/host-check")
     @Operation(summary = "스페이스의 호스트 여부 조회", description = "로그인한 호스트의 스페이스 호스트 여부를 조회합니다.")
     @SecurityRequirement(name = "bearerAuth")
-    public ResponseEntity<CheckSpaceHostResponse> checkHost(
+    public ResponseEntity<ApiResponse<CheckSpaceHostResponse>> checkHost(
         @PathVariable(name = "spaceCode") String spaceCode,
         @LoginHost Host host
     ) {
         var response = spaceService.checkSpaceHost(spaceCode, host);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/forgather/domain/stats/controller/StatsController.java
+++ b/src/main/java/com/forgather/domain/stats/controller/StatsController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.forgather.domain.stats.dto.LandingStatsResponse;
 import com.forgather.domain.stats.service.StatsService;
+import com.forgather.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -24,8 +25,8 @@ public class StatsController {
 
     @Operation(summary = "랜딩 페이지용 통계", description = "서비스 내 모든 스페이스와 방명록 카드의 개수를 반환합니다.")
     @GetMapping("/landing")
-    public ResponseEntity<LandingStatsResponse> landing() {
+    public ResponseEntity<ApiResponse<LandingStatsResponse>> landing() {
         LandingStatsResponse response = statsService.landing();
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/forgather/domain/upload/controller/UploadController.java
+++ b/src/main/java/com/forgather/domain/upload/controller/UploadController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlResponse;
 import com.forgather.domain.upload.service.UploadService;
+import com.forgather.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -31,16 +32,16 @@ public class UploadController {
      */
     @PostMapping(path = "/signed-urls")
     @Operation(summary = "업로드 URL 발급", description = """
-        업로드 파일 별 서명된 URL을 발급합니다.
-        category는 업로드할 사진의 종류를 뜻합니다.
-        작품 사진 : PRODUCT
-        방명록 사진 : GUESTBOOK
-    """)
-    public ResponseEntity<IssueSignedUrlResponse> issuePreSignedUrls(
+            업로드 파일 별 서명된 URL을 발급합니다.
+            category는 업로드할 사진의 종류를 뜻합니다.
+            작품 사진 : PRODUCT
+            방명록 사진 : GUESTBOOK
+        """)
+    public ResponseEntity<ApiResponse<IssueSignedUrlResponse>> issuePreSignedUrls(
         @PathVariable(name = "spaceCode") String spaceCode,
         @RequestBody IssueSignedUrlRequest request
     ) {
         var response = uploadService.issueSignedUrls(spaceCode, request);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/forgather/global/auth/controller/AuthController.java
+++ b/src/main/java/com/forgather/global/auth/controller/AuthController.java
@@ -15,6 +15,7 @@ import com.forgather.global.auth.dto.LoginResponse;
 import com.forgather.global.auth.dto.RefreshRequest;
 import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.service.AuthService;
+import com.forgather.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -32,46 +33,46 @@ public class AuthController {
     @Operation(summary = "내 정보 확인",
         description = "현재 로그인된 사용자의 정보를 확인합니다. " +
             "로그인된 사용자가 없으면 401 Unauthorized를 반환합니다.")
-    public ResponseEntity<HostResponse> getCurrentUser(@LoginHost Host host) {
+    public ResponseEntity<ApiResponse<HostResponse>> getCurrentUser(@LoginHost Host host) {
         var response = authService.getCurrentUser(host);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @GetMapping("/login/kakao")
     @Operation(summary = "Kakao 로그인을 위한 토큰 발급",
         description = "Kakao 로그인 페이지로 리다이렉트하기 위한 URL을 반환합니다.")
-    public ResponseEntity<KakaoLoginTokenResponse> getKakaoLoginToken() {
+    public ResponseEntity<ApiResponse<KakaoLoginTokenResponse>> getKakaoLoginToken() {
         var response = authService.getKakaoLoginToken();
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @PostMapping("/login/kakao/confirm")
     @Operation(summary = "Kakao 로그인 완료",
         description = "Kakao 로그인 후 발급받은 액세스토큰을 전달하여 로그인합니다. " +
             "로그인 성공 시, 액세스토큰과 리프레시토큰을 반환합니다.")
-    public ResponseEntity<LoginResponse> kakaoLoginConfirm(
+    public ResponseEntity<ApiResponse<LoginResponse>> kakaoLoginConfirm(
         @RequestBody KakaoLoginConfirmRequest request
     ) {
         var response = authService.kakaoLoginConfirm(request);
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @PostMapping("/refresh")
     @Operation(summary = "로그인 세션 갱신",
         description = "리프레시 토큰을 사용하여 로그인 세션을 갱신합니다. " +
             "로그인 이력이 있다면 재로그인 없이 로그인 세션을 갱신할 수 있습니다.")
-    public ResponseEntity<LoginResponse> refresh(
+    public ResponseEntity<ApiResponse<LoginResponse>> refresh(
         @RequestBody RefreshRequest request
     ) {
         var response = authService.refresh(request.refreshToken());
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(response));
     }
 
     @PostMapping("/terms")
     @Operation(summary = "서비스 이용 약관 동의",
         description = "서비스 이용 약관에 동의합니다. ")
-    public ResponseEntity<Void> agreeTerms(@LoginHost Host host) {
+    public ResponseEntity<ApiResponse<Void>> agreeTerms(@LoginHost Host host) {
         authService.agreeTerms(host);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(ApiResponse.success());
     }
 }

--- a/src/main/java/com/forgather/global/response/ApiResponse.java
+++ b/src/main/java/com/forgather/global/response/ApiResponse.java
@@ -1,0 +1,20 @@
+package com.forgather.global.response;
+
+public record ApiResponse<T>(
+    ResponseCode code,
+    String message,
+    T data
+) {
+
+    public static ApiResponse<Void> success() {
+        return new ApiResponse<>(ResponseCode.SUCCESS, null, null);
+    }
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(ResponseCode.SUCCESS, null, data);
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(ResponseCode.SUCCESS, message, data);
+    }
+}

--- a/src/main/java/com/forgather/global/response/ResponseCode.java
+++ b/src/main/java/com/forgather/global/response/ResponseCode.java
@@ -1,0 +1,7 @@
+package com.forgather.global.response;
+
+public enum ResponseCode {
+
+    SUCCESS,
+    ;
+}

--- a/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -33,12 +33,15 @@ import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.model.SpaceHostMap;
 import com.forgather.global.auth.repository.SpaceHostMapRepository;
 import com.forgather.global.auth.util.JwtTokenProvider;
+import com.forgather.global.response.ApiResponse;
+import com.forgather.global.response.ResponseCode;
 
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 
 @AutoConfigureMockMvc
-public class GuestBookCardAcceptanceTest extends AcceptanceTest {
+class GuestBookCardAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -103,7 +106,7 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
             writeGuestBookCard(publicSpace);
 
             // when
-            GuestBookResponse result = RestAssuredMockMvc.given()
+            ApiResponse<GuestBookResponse> result = RestAssuredMockMvc.given()
                 .accept(ContentType.JSON)
                 .queryParam("page", 1)
                 .queryParam("size", 15)
@@ -115,15 +118,18 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .statusCode(200)
                 .extract()
                 .body()
-                .as(GuestBookResponse.class);
+                .as(new TypeRef<>() {
+                });
 
             // then
             assertAll(
-                () -> assertThat(result.guestBookCards()).size().isEqualTo(2),
-                () -> assertThat(result.currentPage()).isEqualTo(1),
-                () -> assertThat(result.pageSize()).isEqualTo(15),
-                () -> assertThat(result.totalCount()).isEqualTo(2),
-                () -> assertThat(result.totalPages()).isEqualTo(1)
+                () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(result.message()).isNull(),
+                () -> assertThat(result.data().guestBookCards()).size().isEqualTo(2),
+                () -> assertThat(result.data().currentPage()).isEqualTo(1),
+                () -> assertThat(result.data().pageSize()).isEqualTo(15),
+                () -> assertThat(result.data().totalCount()).isEqualTo(2),
+                () -> assertThat(result.data().totalPages()).isEqualTo(1)
             );
         }
 
@@ -161,7 +167,7 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
             WriteGuestBookCardResponse writeResponseWithNoPhoto = writeGuestBookCardWithNoPhoto(publicSpace);
 
             // when
-            GuestBookResponse result = RestAssuredMockMvc.given()
+            ApiResponse<GuestBookResponse> result = RestAssuredMockMvc.given()
                 .accept(ContentType.JSON)
                 .queryParam("page", 1)
                 .queryParam("size", 15)
@@ -173,21 +179,26 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .statusCode(200)
                 .extract()
                 .body()
-                .as(GuestBookResponse.class);
+                .as(new TypeRef<>() {
+                });
 
             // then
             assertAll(
-                () -> assertThat(result.guestBookCards()).size().isEqualTo(2),
-                () -> assertThat(result.guestBookCards().getFirst().nickname()).isEqualTo(writeResponseWithNoPhoto.nickname()),
-                () -> assertThat(result.guestBookCards().getFirst().containsPhoto()).isFalse(),
-                () -> assertThat(result.guestBookCards().getFirst().isRead()).isNull(),
-                () -> assertThat(result.guestBookCards().getLast().nickname()).isEqualTo(writeResponse.nickname()),
-                () -> assertThat(result.guestBookCards().getLast().containsPhoto()).isTrue(),
-                () -> assertThat(result.guestBookCards().getLast().isRead()).isNull(),
-                () -> assertThat(result.currentPage()).isEqualTo(1),
-                () -> assertThat(result.pageSize()).isEqualTo(15),
-                () -> assertThat(result.totalCount()).isEqualTo(2),
-                () -> assertThat(result.totalPages()).isEqualTo(1)
+                () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(result.message()).isNull(),
+                () -> assertThat(result.data().guestBookCards()).size().isEqualTo(2),
+                () -> assertThat(result.data().guestBookCards().getFirst().nickname()).isEqualTo(
+                    writeResponseWithNoPhoto.nickname()),
+                () -> assertThat(result.data().guestBookCards().getFirst().containsPhoto()).isFalse(),
+                () -> assertThat(result.data().guestBookCards().getFirst().isRead()).isNull(),
+                () -> assertThat(result.data().guestBookCards().getLast().nickname()).isEqualTo(
+                    writeResponse.nickname()),
+                () -> assertThat(result.data().guestBookCards().getLast().containsPhoto()).isTrue(),
+                () -> assertThat(result.data().guestBookCards().getLast().isRead()).isNull(),
+                () -> assertThat(result.data().currentPage()).isEqualTo(1),
+                () -> assertThat(result.data().pageSize()).isEqualTo(15),
+                () -> assertThat(result.data().totalCount()).isEqualTo(2),
+                () -> assertThat(result.data().totalPages()).isEqualTo(1)
             );
         }
 
@@ -281,7 +292,7 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
             WriteGuestBookCardResponse writeResponse = writeGuestBookCard(publicSpace);
 
             // when
-            GuestBookCardResponse result = RestAssuredMockMvc.given()
+            ApiResponse<GuestBookCardResponse> result = RestAssuredMockMvc.given()
                 .accept(ContentType.JSON)
                 .when()
                 .get("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
@@ -289,23 +300,27 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .statusCode(200)
                 .extract()
                 .body()
-                .as(GuestBookCardResponse.class);
+                .as(new TypeRef<>() {
+                });
 
             // then
             assertAll(
-                () -> assertThat(result.id()).isNotNull(),
-                () -> assertThat(result.nickname()).isEqualTo(writeRequest.nickname()),
-                () -> assertThat(result.message()).isEqualTo(writeRequest.message()),
-                () -> assertThat(result.createdAt()).isBetween(LocalDateTime.now().minusMinutes(1), LocalDateTime.now()),
+                () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(result.message()).isNull(),
+                () -> assertThat(result.data().id()).isNotNull(),
+                () -> assertThat(result.data().nickname()).isEqualTo(writeRequest.nickname()),
+                () -> assertThat(result.data().message()).isEqualTo(writeRequest.message()),
+                () -> assertThat(result.data().createdAt()).isBetween(LocalDateTime.now().minusMinutes(1),
+                    LocalDateTime.now()),
 
-                () -> assertThat(result.photos().get(0).originalName()).isEqualTo("photo1.jpg"),
-                () -> assertThat(result.photos().get(0).path()).endsWith("/spaces/1234567890/guestbook/abc.jpg"),
+                () -> assertThat(result.data().photos().get(0).originalName()).isEqualTo("photo1.jpg"),
+                () -> assertThat(result.data().photos().get(0).path()).endsWith("/spaces/1234567890/guestbook/abc.jpg"),
 
-                () -> assertThat(result.photos().get(1).originalName()).isEqualTo("photo2.jpg"),
-                () -> assertThat(result.photos().get(1).path()).endsWith("/spaces/1234567890/guestbook/def.jpg"),
+                () -> assertThat(result.data().photos().get(1).originalName()).isEqualTo("photo2.jpg"),
+                () -> assertThat(result.data().photos().get(1).path()).endsWith("/spaces/1234567890/guestbook/def.jpg"),
 
-                () -> assertThat(result.photos().get(2).originalName()).isEqualTo("photo3.jpg"),
-                () -> assertThat(result.photos().get(2).path()).endsWith("/spaces/1234567890/guestbook/ghi.jpg")
+                () -> assertThat(result.data().photos().get(2).originalName()).isEqualTo("photo3.jpg"),
+                () -> assertThat(result.data().photos().get(2).path()).endsWith("/spaces/1234567890/guestbook/ghi.jpg")
             );
         }
 
@@ -374,7 +389,7 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .statusCode(200);
 
             // then
-            GuestBookResponse result = RestAssuredMockMvc.given()
+            ApiResponse<GuestBookResponse> result = RestAssuredMockMvc.given()
                 .header("Authorization", "Bearer " + accessToken)
                 .accept(ContentType.JSON)
                 .queryParam("page", 1)
@@ -387,9 +402,14 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .statusCode(200)
                 .extract()
                 .body()
-                .as(GuestBookResponse.class);
+                .as(new TypeRef<>() {
+                });
 
-            assertThat(result.guestBookCards().getFirst().isRead()).isTrue();
+            assertAll(
+                () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(result.message()).isNull(),
+                () -> assertThat(result.data().guestBookCards().getFirst().isRead()).isTrue()
+            );
         }
     }
 
@@ -408,7 +428,8 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(result.nickname()).isEqualTo(writeRequest.nickname()),
                 () -> assertThat(result.message()).isEqualTo(writeRequest.message()),
                 () -> assertThat(result.isRead()).isFalse(),
-                () -> assertThat(result.createdAt()).isBetween(LocalDateTime.now().minusMinutes(1), LocalDateTime.now()),
+                () -> assertThat(result.createdAt()).isBetween(LocalDateTime.now().minusMinutes(1),
+                    LocalDateTime.now()),
 
                 () -> assertThat(result.photos().get(0).originalName()).isEqualTo("photo1.jpg"),
                 () -> assertThat(result.photos().get(0).path()).endsWith(
@@ -576,7 +597,7 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .statusCode(204);
 
             // then
-            GuestBookCardResponse response = RestAssuredMockMvc.given()
+            ApiResponse<GuestBookCardResponse> response = RestAssuredMockMvc.given()
                 .accept(ContentType.JSON)
                 .when()
                 .get("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
@@ -584,10 +605,13 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .statusCode(200)
                 .extract()
                 .body()
-                .as(GuestBookCardResponse.class);
+                .as(new TypeRef<>() {
+                });
             assertAll(
-                () -> assertThat(response.photos()).size().isEqualTo(1),
-                () -> assertThat(response.photos().getFirst().id()).isEqualTo(writeResponse.photos().get(1).id())
+                () -> assertThat(response.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(response.message()).isNull(),
+                () -> assertThat(response.data().photos()).size().isEqualTo(1),
+                () -> assertThat(response.data().photos().getFirst().id()).isEqualTo(writeResponse.photos().get(1).id())
             );
         }
 
@@ -663,7 +687,7 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
     }
 
     private WriteGuestBookCardResponse writeGuestBookCard(Space space) {
-        return RestAssuredMockMvc.given()
+        ApiResponse<WriteGuestBookCardResponse> response = RestAssuredMockMvc.given()
             .body(writeRequest)
             .contentType(ContentType.JSON)
             .accept(ContentType.JSON)
@@ -673,7 +697,9 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
             .statusCode(201)
             .extract()
             .body()
-            .as(WriteGuestBookCardResponse.class);
+            .as(new TypeRef<>() {
+            });
+        return response.data();
     }
 
     private WriteGuestBookCardResponse writeGuestBookCardWithNoPhoto(Space space) {
@@ -682,7 +708,7 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
             "message2",
             List.of()
         );
-        return RestAssuredMockMvc.given()
+        ApiResponse<WriteGuestBookCardResponse> response = RestAssuredMockMvc.given()
             .body(writeRequestWithNoPicture)
             .contentType(ContentType.JSON)
             .accept(ContentType.JSON)
@@ -692,6 +718,8 @@ public class GuestBookCardAcceptanceTest extends AcceptanceTest {
             .statusCode(201)
             .extract()
             .body()
-            .as(WriteGuestBookCardResponse.class);
+            .as(new TypeRef<>() {
+            });
+        return response.data();
     }
 }

--- a/src/test/java/com/forgather/acceptance/GuestbookReportAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/GuestbookReportAcceptanceTest.java
@@ -26,17 +26,21 @@ import com.forgather.domain.guestbook.repository.jpa.GuestBookReportReasonJpaRep
 import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.HostRepository;
 import com.forgather.domain.space.repository.SpaceRepository;
+import com.forgather.fixture.SpaceFixture;
 import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.model.SpaceHostMap;
 import com.forgather.global.auth.repository.SpaceHostMapRepository;
 import com.forgather.global.auth.util.JwtTokenProvider;
+import com.forgather.global.response.ApiResponse;
+import com.forgather.global.response.ResponseCode;
 
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 
 @AutoConfigureMockMvc
 @DisplayName("인수 테스트: 방명록 신고")
-public class GuestbookReportAcceptanceTest extends AcceptanceTest {
+class GuestbookReportAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -94,7 +98,7 @@ public class GuestbookReportAcceptanceTest extends AcceptanceTest {
             CreateGuestBookReportRequest request = new CreateGuestBookReportRequest(reason.getId(), null);
 
             // when
-            CreateGuestBookReportResponse response = RestAssuredMockMvc.given()
+            ApiResponse<CreateGuestBookReportResponse> result = RestAssuredMockMvc.given()
                 .header("Authorization", "Bearer " + accessToken)
                 .contentType(ContentType.JSON)
                 .body(request)
@@ -105,12 +109,15 @@ public class GuestbookReportAcceptanceTest extends AcceptanceTest {
                 .statusCode(HttpStatus.CREATED.value())
                 .extract()
                 .body()
-                .as(CreateGuestBookReportResponse.class);
+                .as(new TypeRef<>() {
+                });
 
             // then
             assertAll(
-                () -> assertThat(response.id()).isNotNull(),
-                () -> assertThat(response.guestBookCardId()).isEqualTo(card.getId())
+                () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(result.message()).isNull(),
+                () -> assertThat(result.data().id()).isNotNull(),
+                () -> assertThat(result.data().guestBookCardId()).isEqualTo(card.getId())
             );
         }
 
@@ -175,7 +182,7 @@ public class GuestbookReportAcceptanceTest extends AcceptanceTest {
         @Test
         void throwExceptionWhenCardNotBelongToSpace() {
             // given
-            Space anotherSpace = spaceRepository.save(com.forgather.fixture.SpaceFixture.createSpaceWithCode("ANOTHER123"));
+            Space anotherSpace = spaceRepository.save(SpaceFixture.createSpaceWithCode("ANOTHER123"));
             spaceHostMapRepository.save(new SpaceHostMap(anotherSpace, host));
             GuestBookCard anotherCard = guestBookCardRepository.save(new GuestBookCard(anotherSpace, "nick", "msg"));
             CreateGuestBookReportRequest request = new CreateGuestBookReportRequest(reason.getId(), null);
@@ -253,38 +260,50 @@ public class GuestbookReportAcceptanceTest extends AcceptanceTest {
                     space.getCode(), card.getId());
 
             // when
-            ReportHistoryResponse response = RestAssuredMockMvc.given()
+            ApiResponse<ReportHistoryResponse> result = RestAssuredMockMvc.given()
                 .header("Authorization", "Bearer " + accessToken)
                 .accept(ContentType.JSON)
                 .when()
                 .get("/guestbook/me/reports")
                 .then()
                 .statusCode(HttpStatus.OK.value())
-                .extract().body().as(ReportHistoryResponse.class);
+                .extract()
+                .body()
+                .as(new TypeRef<>() {
+                });
 
             // then
             assertAll(
-                () -> assertThat(response.reportHistory()).hasSize(1),
-                () -> assertThat(response.totalCount()).isEqualTo(1),
-                () -> assertThat(response.reportHistory().get(0).nicknameSnapshot()).isEqualTo("닉네임"),
-                () -> assertThat(response.reportHistory().get(0).messageSnapshot()).isEqualTo("방명록 메시지")
+                () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(result.message()).isNull(),
+                () -> assertThat(result.data().reportHistory()).hasSize(1),
+                () -> assertThat(result.data().totalCount()).isEqualTo(1),
+                () -> assertThat(result.data().reportHistory().get(0).nicknameSnapshot()).isEqualTo("닉네임"),
+                () -> assertThat(result.data().reportHistory().get(0).messageSnapshot()).isEqualTo("방명록 메시지")
             );
         }
 
         @DisplayName("신고 내역이 없으면 빈 목록을 반환한다")
         @Test
         void retrieveReportHistoryEmpty() {
-            ReportHistoryResponse response = RestAssuredMockMvc.given()
+            ApiResponse<ReportHistoryResponse> result = RestAssuredMockMvc.given()
                 .header("Authorization", "Bearer " + accessToken)
                 .accept(ContentType.JSON)
                 .when()
                 .get("/guestbook/me/reports")
                 .then()
                 .statusCode(HttpStatus.OK.value())
-                .extract().body().as(ReportHistoryResponse.class);
+                .extract()
+                .body()
+                .as(new TypeRef<>() {
+                });
 
-            assertThat(response.reportHistory()).isEmpty();
-            assertThat(response.totalCount()).isEqualTo(0);
+            assertAll(
+                () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(result.message()).isNull(),
+                () -> assertThat(result.data().reportHistory()).isEmpty(),
+                () -> assertThat(result.data().totalCount()).isEqualTo(0)
+            );
         }
 
         @DisplayName("비로그인 사용자는 조회할 수 없다")

--- a/src/test/java/com/forgather/acceptance/ProductAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/ProductAcceptanceTest.java
@@ -32,12 +32,15 @@ import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.model.SpaceHostMap;
 import com.forgather.global.auth.repository.SpaceHostMapRepository;
 import com.forgather.global.auth.util.JwtTokenProvider;
+import com.forgather.global.response.ApiResponse;
+import com.forgather.global.response.ResponseCode;
 
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 
 @AutoConfigureMockMvc
-public class ProductAcceptanceTest extends AcceptanceTest {
+class ProductAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -106,7 +109,7 @@ public class ProductAcceptanceTest extends AcceptanceTest {
             ProductResponse registerResponse2 = registerProductV3();
 
             // when
-            ProductsResponse result = RestAssuredMockMvc.given()
+            ApiResponse<ProductsResponse> result = RestAssuredMockMvc.given()
                 .header("X-API-Version", "3")
                 .accept(ContentType.JSON)
                 .when()
@@ -115,23 +118,27 @@ public class ProductAcceptanceTest extends AcceptanceTest {
                 .statusCode(200)
                 .extract()
                 .body()
-                .as(ProductsResponse.class);
+                .as(new TypeRef<>() {
+                });
 
             // then
             assertAll(
-                () -> assertThat(result.products().getFirst().id()).isEqualTo(registerResponse1.id()),
-                () -> assertThat(result.products().getFirst().title()).isEqualTo(registerResponse1.title()),
-                () -> assertThat(result.products().getFirst().category()).isEqualTo(registerResponse1.category()),
-                () -> assertThat(result.products().getFirst().videoUrl()).isEqualTo(registerResponse1.videoUrl()),
+                () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(result.message()).isNull(),
+                () -> assertThat(result.data().products().get(0).id()).isEqualTo(registerResponse1.id()),
+                () -> assertThat(result.data().products().get(0).title()).isEqualTo(registerResponse1.title()),
+                () -> assertThat(result.data().products().get(0).category()).isEqualTo(registerResponse1.category()),
+                () -> assertThat(result.data().products().get(0).videoUrl()).isEqualTo(registerResponse1.videoUrl()),
 
-                () -> assertThat(result.products().get(1).id()).isEqualTo(registerResponse2.id()),
-                () -> assertThat(result.products().get(1).title()).isEqualTo(registerResponse2.title()),
-                () -> assertThat(result.products().get(1).category()).isEqualTo(registerResponse2.category()),
-                () -> assertThat(result.products().get(1).videoUrl()).isEqualTo(registerResponse2.videoUrl()),
+                () -> assertThat(result.data().products().get(1).id()).isEqualTo(registerResponse2.id()),
+                () -> assertThat(result.data().products().get(1).title()).isEqualTo(registerResponse2.title()),
+                () -> assertThat(result.data().products().get(1).category()).isEqualTo(registerResponse2.category()),
+                () -> assertThat(result.data().products().get(1).videoUrl()).isEqualTo(registerResponse2.videoUrl()),
 
-                () -> assertThat(result.products().getFirst().firstPhoto().originalName()).isEqualTo("photo1"),
-                () -> assertThat(result.products().getFirst().firstPhoto().path()).endsWith("/spaces/1234567890/product/file1.png"),
-                () -> assertThat(result.products().getFirst().firstPhoto().order()).isEqualTo(1)
+                () -> assertThat(result.data().products().get(0).firstPhoto().originalName()).isEqualTo("photo1"),
+                () -> assertThat(result.data().products().get(0).firstPhoto().path()).endsWith(
+                    "/spaces/1234567890/product/file1.png"),
+                () -> assertThat(result.data().products().get(0).firstPhoto().order()).isEqualTo(1)
             );
         }
 
@@ -139,7 +146,7 @@ public class ProductAcceptanceTest extends AcceptanceTest {
         @Test
         void returnEmptyListWhenNoProducts() {
             // when
-            ProductsResponse result = RestAssuredMockMvc.given()
+            ApiResponse<ProductsResponse> result = RestAssuredMockMvc.given()
                 .header("X-API-Version", "3")
                 .accept(ContentType.JSON)
                 .when()
@@ -148,10 +155,15 @@ public class ProductAcceptanceTest extends AcceptanceTest {
                 .statusCode(200)
                 .extract()
                 .body()
-                .as(ProductsResponse.class);
+                .as(new TypeRef<>() {
+                });
 
             // then
-            assertThat(result.products()).isEmpty();
+            assertAll(
+                () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(result.message()).isNull(),
+                () -> assertThat(result.data().products()).isEmpty()
+            );
         }
     }
 
@@ -164,7 +176,7 @@ public class ProductAcceptanceTest extends AcceptanceTest {
             ProductResponse registerResponse = registerProductV3();
 
             // when
-            ProductResponse result = RestAssuredMockMvc.given()
+            ApiResponse<ProductResponse> result = RestAssuredMockMvc.given()
                 .header("X-API-Version", "1")
                 .accept(ContentType.JSON)
                 .when()
@@ -173,26 +185,29 @@ public class ProductAcceptanceTest extends AcceptanceTest {
                 .statusCode(200)
                 .extract()
                 .body()
-                .as(ProductResponse.class);
+                .as(new TypeRef<>() {
+                });
 
             // then
             assertAll(
-                () -> assertThat(result.id()).isEqualTo(registerResponse.id()),
-                () -> assertThat(result.title()).isEqualTo(registerResponse.title()),
-                () -> assertThat(result.category()).isEqualTo(registerResponse.category()),
-                () -> assertThat(result.authorName()).isEqualTo(registerResponse.authorName()),
-                () -> assertThat(result.description()).isEqualTo(registerResponse.description()),
-                () -> assertThat(result.videoUrl()).isEqualTo(registerResponse.videoUrl()),
-                () -> assertThat(result.isVideoAfterPhoto()).isEqualTo(registerResponse.isVideoAfterPhoto()),
-                () -> assertThat(result.photos().get(0).originalName()).isEqualTo("photo1"),
-                () -> assertThat(result.photos().get(0).path()).endsWith("/spaces/1234567890/product/file1.png"),
-                () -> assertThat(result.photos().get(0).order()).isEqualTo(1),
-                () -> assertThat(result.photos().get(1).originalName()).isEqualTo("photo2"),
-                () -> assertThat(result.photos().get(1).path()).endsWith("/spaces/1234567890/product/file2.png"),
-                () -> assertThat(result.photos().get(1).order()).isEqualTo(2),
-                () -> assertThat(result.photos().get(2).originalName()).isEqualTo("photo3"),
-                () -> assertThat(result.photos().get(2).path()).endsWith("/spaces/1234567890/product/file3.png"),
-                () -> assertThat(result.photos().get(2).order()).isEqualTo(3)
+                () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(result.message()).isNull(),
+                () -> assertThat(result.data().id()).isEqualTo(registerResponse.id()),
+                () -> assertThat(result.data().title()).isEqualTo(registerResponse.title()),
+                () -> assertThat(result.data().category()).isEqualTo(registerResponse.category()),
+                () -> assertThat(result.data().authorName()).isEqualTo(registerResponse.authorName()),
+                () -> assertThat(result.data().description()).isEqualTo(registerResponse.description()),
+                () -> assertThat(result.data().videoUrl()).isEqualTo(registerResponse.videoUrl()),
+                () -> assertThat(result.data().isVideoAfterPhoto()).isEqualTo(registerResponse.isVideoAfterPhoto()),
+                () -> assertThat(result.data().photos().get(0).originalName()).isEqualTo("photo1"),
+                () -> assertThat(result.data().photos().get(0).path()).endsWith("/spaces/1234567890/product/file1.png"),
+                () -> assertThat(result.data().photos().get(0).order()).isEqualTo(1),
+                () -> assertThat(result.data().photos().get(1).originalName()).isEqualTo("photo2"),
+                () -> assertThat(result.data().photos().get(1).path()).endsWith("/spaces/1234567890/product/file2.png"),
+                () -> assertThat(result.data().photos().get(1).order()).isEqualTo(2),
+                () -> assertThat(result.data().photos().get(2).originalName()).isEqualTo("photo3"),
+                () -> assertThat(result.data().photos().get(2).path()).endsWith("/spaces/1234567890/product/file3.png"),
+                () -> assertThat(result.data().photos().get(2).order()).isEqualTo(3)
             );
         }
 
@@ -218,7 +233,7 @@ public class ProductAcceptanceTest extends AcceptanceTest {
         @Test
         void register() {
             // when
-            ProductResponse response = RestAssuredMockMvc.given()
+            ApiResponse<ProductResponse> response = RestAssuredMockMvc.given()
                 .header("Authorization", "Bearer " + accessToken)
                 .header("X-API-Version", "3")
                 .body(registerRequest)
@@ -230,26 +245,32 @@ public class ProductAcceptanceTest extends AcceptanceTest {
                 .statusCode(201)
                 .extract()
                 .body()
-                .as(ProductResponse.class);
+                .as(new TypeRef<>() {
+                });
 
             // then
             assertAll(
-                () -> assertThat(response.id()).isNotNull(),
-                () -> assertThat(response.title()).isEqualTo(registerRequest.title()),
-                () -> assertThat(response.category()).isEqualTo(registerRequest.category()),
-                () -> assertThat(response.authorName()).isEqualTo(registerRequest.authorName()),
-                () -> assertThat(response.description()).isEqualTo(registerRequest.description()),
-                () -> assertThat(response.videoUrl()).isEqualTo(registerRequest.videoUrl()),
-                () -> assertThat(response.isVideoAfterPhoto()).isEqualTo(registerRequest.isVideoAfterPhoto()),
-                () -> assertThat(response.photos().get(0).originalName()).isEqualTo("photo1"),
-                () -> assertThat(response.photos().get(0).path()).endsWith("/spaces/1234567890/product/file1.png"),
-                () -> assertThat(response.photos().get(0).order()).isEqualTo(1),
-                () -> assertThat(response.photos().get(1).originalName()).isEqualTo("photo2"),
-                () -> assertThat(response.photos().get(1).path()).endsWith("/spaces/1234567890/product/file2.png"),
-                () -> assertThat(response.photos().get(1).order()).isEqualTo(2),
-                () -> assertThat(response.photos().get(2).originalName()).isEqualTo("photo3"),
-                () -> assertThat(response.photos().get(2).path()).endsWith("/spaces/1234567890/product/file3.png"),
-                () -> assertThat(response.photos().get(2).order()).isEqualTo(3)
+                () -> assertThat(response.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(response.message()).isNull(),
+                () -> assertThat(response.data().id()).isNotNull(),
+                () -> assertThat(response.data().title()).isEqualTo(registerRequest.title()),
+                () -> assertThat(response.data().category()).isEqualTo(registerRequest.category()),
+                () -> assertThat(response.data().authorName()).isEqualTo(registerRequest.authorName()),
+                () -> assertThat(response.data().description()).isEqualTo(registerRequest.description()),
+                () -> assertThat(response.data().videoUrl()).isEqualTo(registerRequest.videoUrl()),
+                () -> assertThat(response.data().isVideoAfterPhoto()).isEqualTo(registerRequest.isVideoAfterPhoto()),
+                () -> assertThat(response.data().photos().get(0).originalName()).isEqualTo("photo1"),
+                () -> assertThat(response.data().photos().get(0).path()).endsWith(
+                    "/spaces/1234567890/product/file1.png"),
+                () -> assertThat(response.data().photos().get(0).order()).isEqualTo(1),
+                () -> assertThat(response.data().photos().get(1).originalName()).isEqualTo("photo2"),
+                () -> assertThat(response.data().photos().get(1).path()).endsWith(
+                    "/spaces/1234567890/product/file2.png"),
+                () -> assertThat(response.data().photos().get(1).order()).isEqualTo(2),
+                () -> assertThat(response.data().photos().get(2).originalName()).isEqualTo("photo3"),
+                () -> assertThat(response.data().photos().get(2).path()).endsWith(
+                    "/spaces/1234567890/product/file3.png"),
+                () -> assertThat(response.data().photos().get(2).order()).isEqualTo(3)
             );
         }
 
@@ -379,7 +400,7 @@ public class ProductAcceptanceTest extends AcceptanceTest {
             );
 
             // when
-            ProductResponse result = RestAssuredMockMvc.given()
+            ApiResponse<ProductResponse> result = RestAssuredMockMvc.given()
                 .header("Authorization", "Bearer " + accessToken)
                 .header("X-API-Version", "1")
                 .body(request)
@@ -391,29 +412,32 @@ public class ProductAcceptanceTest extends AcceptanceTest {
                 .statusCode(200)
                 .extract()
                 .body()
-                .as(ProductResponse.class);
+                .as(new TypeRef<>() {
+                });
 
             // then
             assertAll(
-                () -> assertThat(result.id()).isEqualTo(registerResponse.id()),
-                () -> assertThat(result.title()).isEqualTo(request.title()),
-                () -> assertThat(result.category()).isEqualTo(registerResponse.category()),
-                () -> assertThat(result.authorName()).isEqualTo(registerResponse.authorName()),
-                () -> assertThat(result.description()).isEqualTo(request.description()),
-                () -> assertThat(result.videoUrl()).isEqualTo(request.videoUrl()),
-                () -> assertThat(result.isVideoAfterPhoto()).isEqualTo(request.isVideoAfterPhoto()),
-                () -> assertThat(result.photos().get(0).originalName()).isEqualTo("photo1"),
-                () -> assertThat(result.photos().get(0).path()).endsWith("/spaces/1234567890/product/file1.png"),
-                () -> assertThat(result.photos().get(0).order()).isEqualTo(1),
-                () -> assertThat(result.photos().get(1).originalName()).isEqualTo("photo3"),
-                () -> assertThat(result.photos().get(1).path()).endsWith("/spaces/1234567890/product/file3.png"),
-                () -> assertThat(result.photos().get(1).order()).isEqualTo(2),
-                () -> assertThat(result.photos().get(2).originalName()).isEqualTo("photo4"),
-                () -> assertThat(result.photos().get(2).path()).endsWith("/spaces/1234567890/product/file4.png"),
-                () -> assertThat(result.photos().get(2).order()).isEqualTo(3),
-                () -> assertThat(result.photos().get(3).originalName()).isEqualTo("photo5"),
-                () -> assertThat(result.photos().get(3).path()).endsWith("/spaces/1234567890/product/file5.png"),
-                () -> assertThat(result.photos().get(3).order()).isEqualTo(4)
+                () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(result.message()).isNull(),
+                () -> assertThat(result.data().id()).isEqualTo(registerResponse.id()),
+                () -> assertThat(result.data().title()).isEqualTo(request.title()),
+                () -> assertThat(result.data().category()).isEqualTo(registerResponse.category()),
+                () -> assertThat(result.data().authorName()).isEqualTo(registerResponse.authorName()),
+                () -> assertThat(result.data().description()).isEqualTo(request.description()),
+                () -> assertThat(result.data().videoUrl()).isEqualTo(request.videoUrl()),
+                () -> assertThat(result.data().isVideoAfterPhoto()).isEqualTo(request.isVideoAfterPhoto()),
+                () -> assertThat(result.data().photos().get(0).originalName()).isEqualTo("photo1"),
+                () -> assertThat(result.data().photos().get(0).path()).endsWith("/spaces/1234567890/product/file1.png"),
+                () -> assertThat(result.data().photos().get(0).order()).isEqualTo(1),
+                () -> assertThat(result.data().photos().get(1).originalName()).isEqualTo("photo3"),
+                () -> assertThat(result.data().photos().get(1).path()).endsWith("/spaces/1234567890/product/file3.png"),
+                () -> assertThat(result.data().photos().get(1).order()).isEqualTo(2),
+                () -> assertThat(result.data().photos().get(2).originalName()).isEqualTo("photo4"),
+                () -> assertThat(result.data().photos().get(2).path()).endsWith("/spaces/1234567890/product/file4.png"),
+                () -> assertThat(result.data().photos().get(2).order()).isEqualTo(3),
+                () -> assertThat(result.data().photos().get(3).originalName()).isEqualTo("photo5"),
+                () -> assertThat(result.data().photos().get(3).path()).endsWith("/spaces/1234567890/product/file5.png"),
+                () -> assertThat(result.data().photos().get(3).order()).isEqualTo(4)
             );
         }
 
@@ -577,7 +601,7 @@ public class ProductAcceptanceTest extends AcceptanceTest {
     }
 
     private ProductResponse registerProductV3() {
-        return RestAssuredMockMvc.given()
+        ApiResponse<ProductResponse> response = RestAssuredMockMvc.given()
             .header("Authorization", "Bearer " + accessToken)
             .header("X-API-Version", "3")
             .body(registerRequest)
@@ -589,6 +613,8 @@ public class ProductAcceptanceTest extends AcceptanceTest {
             .statusCode(201)
             .extract()
             .body()
-            .as(ProductResponse.class);
+            .as(new TypeRef<>() {
+            });
+        return response.data();
     }
 }

--- a/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
@@ -50,7 +50,10 @@ import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.model.SpaceHostMap;
 import com.forgather.global.auth.repository.SpaceHostMapRepository;
 import com.forgather.global.auth.util.JwtTokenProvider;
+import com.forgather.global.response.ApiResponse;
+import com.forgather.global.response.ResponseCode;
 
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 
 @DisplayName("인수 테스트: Space")
@@ -123,7 +126,7 @@ class SpaceAcceptanceTest extends AcceptanceTest {
         );
 
         // when
-        CreateSpaceResponse response = RestAssuredMockMvc.given()
+        ApiResponse<CreateSpaceResponse> response = RestAssuredMockMvc.given()
             .header("Authorization", "Bearer " + token)
             .multiPart("request", request, "application/json")
             .multiPart("file", file.getOriginalFilename(), file.getBytes(), file.getContentType())
@@ -133,10 +136,15 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             .statusCode(HttpStatus.CREATED.value())
             .extract()
             .body()
-            .as(CreateSpaceResponse.class);
+            .as(new TypeRef<>() {
+            });
 
         // then
-        assertThat(response.spaceCode()).isNotEmpty();
+        assertAll(
+            () -> assertThat(response.code()).isEqualTo(ResponseCode.SUCCESS),
+            () -> assertThat(response.message()).isNull(),
+            () -> assertThat(response.data().spaceCode()).isNotEmpty()
+        );
     }
 
     @DisplayName("스페이스 사진이 없는 스페이스를 생성한다.")
@@ -149,7 +157,7 @@ class SpaceAcceptanceTest extends AcceptanceTest {
         );
 
         // when
-        CreateSpaceResponse response = RestAssuredMockMvc.given()
+        ApiResponse<CreateSpaceResponse> response = RestAssuredMockMvc.given()
             .header("Authorization", "Bearer " + token)
             .multiPart("request", request, "application/json")
             .when()
@@ -158,10 +166,15 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             .statusCode(HttpStatus.CREATED.value())
             .extract()
             .body()
-            .as(CreateSpaceResponse.class);
+            .as(new TypeRef<>() {
+            });
 
         // then
-        assertThat(response.spaceCode()).isNotEmpty();
+        assertAll(
+            () -> assertThat(response.code()).isEqualTo(ResponseCode.SUCCESS),
+            () -> assertThat(response.message()).isNull(),
+            () -> assertThat(response.data().spaceCode()).isNotEmpty()
+        );
     }
 
     @DisplayName("스페이스를 생성하려면 로그인이 필요하다.")
@@ -196,7 +209,7 @@ class SpaceAcceptanceTest extends AcceptanceTest {
         guestBookCardRepository.save(GuestBookCardFixture.createGuestBookCard(space, "nickname2", "카드2"));
 
         // when
-        SpaceResponse result = RestAssuredMockMvc.given()
+        ApiResponse<SpaceResponse> result = RestAssuredMockMvc.given()
             .header("Authorization", "Bearer " + token)
             .when()
             .get("/spaces/{spaceCode}", space.getCode())
@@ -204,13 +217,16 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             .statusCode(HttpStatus.OK.value())
             .extract()
             .body()
-            .as(SpaceResponse.class);
+            .as(new TypeRef<>() {
+            });
 
         // then
         assertAll(
-            () -> assertThat(result.spaceCode()).isEqualTo(space.getCode()),
-            () -> assertThat(result.spacePhoto().path()).isEqualTo(spacePhoto.getPath()),
-            () -> assertThat(result.guestBookCardCount()).isEqualTo(2)
+            () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+            () -> assertThat(result.message()).isNull(),
+            () -> assertThat(result.data().spaceCode()).isEqualTo(space.getCode()),
+            () -> assertThat(result.data().spacePhoto().path()).isEqualTo(spacePhoto.getPath()),
+            () -> assertThat(result.data().guestBookCardCount()).isEqualTo(2)
         );
     }
 
@@ -332,7 +348,7 @@ class SpaceAcceptanceTest extends AcceptanceTest {
         );
 
         // when
-        SpaceResponse result = RestAssuredMockMvc.given()
+        ApiResponse<SpaceResponse> result = RestAssuredMockMvc.given()
             .header("Authorization", "Bearer " + token)
             .multiPart("request", request, "application/json")
             .multiPart("file", newFile.getOriginalFilename(), newFile.getBytes(), newFile.getContentType())
@@ -342,17 +358,20 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             .statusCode(HttpStatus.OK.value())
             .extract()
             .body()
-            .as(SpaceResponse.class);
+            .as(new TypeRef<>() {
+            });
 
         // then
         assertAll(
-            () -> assertThat(result.name()).isEqualTo("새로운 스페이스"),
-            () -> assertThat(result.description()).isEqualTo("새로운 설명"),
-            () -> assertThat(result.isPublic()).isFalse(),
-            () -> assertThat(result.instagramUsername()).isEqualTo("forgather_official_new"),
-            () -> assertThat(result.email()).isEqualTo("forgather_new@forgather.me"),
+            () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+            () -> assertThat(result.message()).isNull(),
+            () -> assertThat(result.data().name()).isEqualTo("새로운 스페이스"),
+            () -> assertThat(result.data().description()).isEqualTo("새로운 설명"),
+            () -> assertThat(result.data().isPublic()).isFalse(),
+            () -> assertThat(result.data().instagramUsername()).isEqualTo("forgather_official_new"),
+            () -> assertThat(result.data().email()).isEqualTo("forgather_new@forgather.me"),
             () -> assertThat(spacePhotoRepository.getBySpaceAndDeletedAtIsNullOrEmpty(space).getOriginalName()).isEqualTo("new.jpg"),
-            () -> assertThat(result.guestBookCardCount()).isZero()
+            () -> assertThat(result.data().guestBookCardCount()).isZero()
         );
     }
 
@@ -369,7 +388,7 @@ class SpaceAcceptanceTest extends AcceptanceTest {
         );
 
         // when
-        SpaceResponse response = RestAssuredMockMvc.given()
+        ApiResponse<SpaceResponse> response = RestAssuredMockMvc.given()
             .header("Authorization", "Bearer " + token)
             .multiPart("request", request, "application/json")
             .when()
@@ -378,16 +397,19 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             .statusCode(HttpStatus.OK.value())
             .extract()
             .body()
-            .as(SpaceResponse.class);
+            .as(new TypeRef<>() {
+            });
 
         // then
         assertAll(
-            () -> assertThat(response.name()).isEqualTo("새로운 스페이스"),
-            () -> assertThat(response.description()).isEqualTo("description"),
-            () -> assertThat(response.isPublic()).isTrue(),
-            () -> assertThat(response.instagramUsername()).isEqualTo("instagramUsername"),
-            () -> assertThat(response.email()).isEqualTo("email@forgather.me"),
-            () -> assertThat(response.spacePhoto().path()).isEqualTo("path"),
+            () -> assertThat(response.code()).isEqualTo(ResponseCode.SUCCESS),
+            () -> assertThat(response.message()).isNull(),
+            () -> assertThat(response.data().name()).isEqualTo("새로운 스페이스"),
+            () -> assertThat(response.data().description()).isEqualTo("description"),
+            () -> assertThat(response.data().isPublic()).isTrue(),
+            () -> assertThat(response.data().instagramUsername()).isEqualTo("instagramUsername"),
+            () -> assertThat(response.data().email()).isEqualTo("email@forgather.me"),
+            () -> assertThat(response.data().spacePhoto().path()).isEqualTo("path"),
 
             () -> verify(contentsStorage, never()).deletePhotos(anyList())
         );
@@ -458,7 +480,7 @@ class SpaceAcceptanceTest extends AcceptanceTest {
         guestBookCardRepository.save(GuestBookCardFixture.createGuestBookCard(space1, "nickname", "방명록1"));
 
         // when
-        HostSpaceResponse result = RestAssuredMockMvc.given()
+        ApiResponse<HostSpaceResponse> result = RestAssuredMockMvc.given()
             .header("Authorization", "Bearer " + token)
             .when()
             .get("/spaces/me")
@@ -466,15 +488,18 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             .statusCode(HttpStatus.OK.value())
             .extract()
             .body()
-            .as(HostSpaceResponse.class);
+            .as(new TypeRef<>() {
+            });
 
         // then
         assertAll(
-            () -> assertThat(result.spaces().getFirst().spaceCode()).isEqualTo(space2.getCode()),
-            () -> assertThat(result.spaces().getFirst().guestBookCardCount()).isZero(),
+            () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+            () -> assertThat(result.message()).isNull(),
+            () -> assertThat(result.data().spaces().getFirst().spaceCode()).isEqualTo(space2.getCode()),
+            () -> assertThat(result.data().spaces().getFirst().guestBookCardCount()).isZero(),
 
-            () -> assertThat(result.spaces().getLast().spaceCode()).isEqualTo(space1.getCode()),
-            () -> assertThat(result.spaces().getLast().guestBookCardCount()).isOne()
+            () -> assertThat(result.data().spaces().getLast().spaceCode()).isEqualTo(space1.getCode()),
+            () -> assertThat(result.data().spaces().getLast().guestBookCardCount()).isOne()
         );
     }
 }

--- a/src/test/java/com/forgather/acceptance/StatsAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/StatsAcceptanceTest.java
@@ -16,12 +16,15 @@ import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.stats.dto.LandingStatsResponse;
 import com.forgather.fixture.GuestBookCardFixture;
 import com.forgather.fixture.SpaceFixture;
+import com.forgather.global.response.ApiResponse;
+import com.forgather.global.response.ResponseCode;
 
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 
 @AutoConfigureMockMvc
-public class StatsAcceptanceTest extends AcceptanceTest{
+class StatsAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -33,13 +36,13 @@ public class StatsAcceptanceTest extends AcceptanceTest{
     private GuestBookCardRepository guestBookCardRepository;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         RestAssuredMockMvc.mockMvc(mockMvc);
     }
 
     @DisplayName("랜딩 페이지용 통계로 스페이스와 방명록 카드의 총 개수를 조회한다")
     @Test
-    public void landing() {
+    void landing() {
         // given
         Space space1 = spaceRepository.save(SpaceFixture.createSpace());
         Space space2 = spaceRepository.save(SpaceFixture.createSpaceWithCode("0123456789"));
@@ -50,7 +53,7 @@ public class StatsAcceptanceTest extends AcceptanceTest{
         guestBookCardRepository.save(GuestBookCardFixture.createGuestBookCardWithSpace(space2));
 
         // when
-        LandingStatsResponse result = RestAssuredMockMvc.given()
+        ApiResponse<LandingStatsResponse> result = RestAssuredMockMvc.given()
             .accept(ContentType.JSON)
             .when()
             .get("/stats/landing")
@@ -58,12 +61,15 @@ public class StatsAcceptanceTest extends AcceptanceTest{
             .statusCode(200)
             .extract()
             .body()
-            .as(LandingStatsResponse.class);
+            .as(new TypeRef<>() {
+            });
 
         // then
         assertAll(
-            () -> assertThat(result.spaceStats().spaceCount()).isEqualTo(2),
-            () -> assertThat(result.guestBookStats().cardCount()).isEqualTo(5)
+            () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+            () -> assertThat(result.message()).isNull(),
+            () -> assertThat(result.data().spaceStats().spaceCount()).isEqualTo(2),
+            () -> assertThat(result.data().guestBookStats().cardCount()).isEqualTo(5)
         );
     }
 }

--- a/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
@@ -18,17 +18,20 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
-import com.forgather.domain.upload.dto.IssueSignedUrlResponse;
 import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.AwsS3Cloud;
+import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
+import com.forgather.domain.upload.dto.IssueSignedUrlResponse;
+import com.forgather.global.response.ApiResponse;
+import com.forgather.global.response.ResponseCode;
 
+import io.restassured.common.mapper.TypeRef;
 import io.restassured.http.ContentType;
 import io.restassured.module.mockmvc.RestAssuredMockMvc;
 
 @AutoConfigureMockMvc
-public class UploadAcceptanceTest extends AcceptanceTest {
+class UploadAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -50,7 +53,7 @@ public class UploadAcceptanceTest extends AcceptanceTest {
 
     @DisplayName("서명된 url 발급")
     @Test
-    public void issueSignedUrls() {
+    void issueSignedUrls() {
         // given
         IssueSignedUrlRequest request = new IssueSignedUrlRequest(GUESTBOOK, List.of("abc.jpg", "def.jpg", "hij.png"));
         when(awsS3Cloud.getRootDirectory()).thenReturn("photogather/v2");
@@ -60,7 +63,7 @@ public class UploadAcceptanceTest extends AcceptanceTest {
         });
 
         // when
-        Map<String, String> result = RestAssuredMockMvc.given()
+        ApiResponse<IssueSignedUrlResponse> result = RestAssuredMockMvc.given()
             .contentType(ContentType.JSON)
             .accept(ContentType.JSON)
             .body(request)
@@ -70,16 +73,19 @@ public class UploadAcceptanceTest extends AcceptanceTest {
             .statusCode(200)
             .extract()
             .body()
-            .as(IssueSignedUrlResponse.class)
-            .signedUrls();
+            .as(new TypeRef<>() {
+            });
+        Map<String, String> signedUrls = result.data().signedUrls();
 
         // then
         assertAll(
-            () -> assertThat(result.get("abc.jpg"))
+            () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+            () -> assertThat(result.message()).isNull(),
+            () -> assertThat(signedUrls.get("abc.jpg"))
                 .isEqualTo("test-prefix-photogather/v2/spaces/1234567890/guestbook/abc.jpg-test-suffix"),
-            () -> assertThat(result.get("def.jpg"))
+            () -> assertThat(signedUrls.get("def.jpg"))
                 .isEqualTo("test-prefix-photogather/v2/spaces/1234567890/guestbook/def.jpg-test-suffix"),
-            () -> assertThat(result.get("hij.png"))
+            () -> assertThat(signedUrls.get("hij.png"))
                 .isEqualTo("test-prefix-photogather/v2/spaces/1234567890/guestbook/hij.png-test-suffix")
         );
     }

--- a/src/test/java/com/forgather/global/response/ApiResponseTest.java
+++ b/src/test/java/com/forgather/global/response/ApiResponseTest.java
@@ -1,0 +1,97 @@
+package com.forgather.global.response;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+class ApiResponseTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Nested
+    @DisplayName("정적 팩토리 메서드")
+    class StaticFactoryMethods {
+
+        @DisplayName("success(data)는 SUCCESS 코드와 null 메시지로 데이터를 감싼다")
+        @Test
+        void success_withData() {
+            // given
+            String data = "hello";
+
+            // when
+            ApiResponse<String> response = ApiResponse.success(data);
+
+            // then
+            assertThat(response.code()).isEqualTo(ResponseCode.SUCCESS);
+            assertThat(response.message()).isNull();
+            assertThat(response.data()).isEqualTo(data);
+        }
+
+        @DisplayName("success()는 데이터 없이 SUCCESS 코드만 담는다")
+        @Test
+        void success_noData() {
+            // when
+            ApiResponse<Void> response = ApiResponse.success();
+
+            // then
+            assertThat(response.code()).isEqualTo(ResponseCode.SUCCESS);
+            assertThat(response.message()).isNull();
+            assertThat(response.data()).isNull();
+        }
+
+        @DisplayName("success(message, data)는 메시지와 데이터를 함께 담는다")
+        @Test
+        void success_withMessageAndData() {
+            // given
+            String message = "정상 처리되었습니다";
+            Integer data = 42;
+
+            // when
+            ApiResponse<Integer> response = ApiResponse.success(message, data);
+
+            // then
+            assertThat(response.code()).isEqualTo(ResponseCode.SUCCESS);
+            assertThat(response.message()).isEqualTo(message);
+            assertThat(response.data()).isEqualTo(data);
+        }
+    }
+
+    @Nested
+    @DisplayName("JSON 직렬화")
+    class Serialization {
+
+        @DisplayName("envelope 직렬화 결과는 code, message, data 세 필드만 갖는다 (null 포함)")
+        @Test
+        void serialize_keepsAllThreeFields() {
+            // given
+            ApiResponse<String> response = ApiResponse.success("hello");
+
+            // when
+            JsonNode node = objectMapper.valueToTree(response);
+
+            // then
+            assertThat(node.fieldNames()).toIterable()
+                .containsExactlyInAnyOrder("code", "message", "data");
+        }
+
+        @DisplayName("code는 SUCCESS 문자열로 직렬화되고 비어있는 message/data는 null로 표현된다")
+        @Test
+        void serialize_codeAsString_withNullFields() {
+            // given
+            ApiResponse<Void> response = ApiResponse.success();
+
+            // when
+            JsonNode node = objectMapper.valueToTree(response);
+
+            // then
+            assertThat(node.get("code").asText()).isEqualTo("SUCCESS");
+            assertThat(node.get("message").isNull()).isTrue();
+            assertThat(node.get("data").isNull()).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## 연관된 이슈

- close #80 

## 작업 내용

모든 REST API의 성공 응답을 `{ code, message, data }` 공통 포맷으로 감싸 응답 계약을 일관화 시켰습니다.

```json
{ "code": "SUCCESS", "message": null, "data": { ... } }
```

- 단일 객체 / 리스트 / null 모두 `data`에 담깁니다
- `204 No Content`는 미적용(HTTP 표준 준수를 위해)

## 주요 변경
1. 공통 포맷 도입
   - `global/response/ApiResponse.java` — `record ApiResponse<T>(ResponseCode, String, T)` + 정적 팩토리(`success()`, `success(data)`, `success(message, data)`)
   - `global/response/ResponseCode.java` — `SUCCESS` enum (에러 코드는 다음 PR에서 동일 enum에 추가)
2. 컨트롤러 6개 래핑: `Auth`, `Stats`, `Upload`, `Space`, `Product`, `GuestBook`(`SpaceGuestbook` + 신규 `Guestbook`)
   - 모든 성공 응답을 `ApiResponse.success(...)`로 감쌈
4. 인수 테스트 표준 패턴 적용: 모든 성공 시나리오에서 `code/message/data` 3가지를 명시적으로 검증


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 모든 API 응답을 표준화된 형식으로 통일했습니다. 응답에는 상태 코드, 메시지, 데이터가 포함되어 있습니다.
  * 주요 API 엔드포인트(제품, 공간, 통계, 업로드, 인증, 방명록 관련)의 응답 구조를 개선했습니다.
  * 테스트를 새로운 응답 형식에 맞게 업데이트했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->