### PR TITLE
chore: 워크플로우 추가

### DIFF
--- a/.github/scripts/sync-merged-pr-to-wiki.sh
+++ b/.github/scripts/sync-merged-pr-to-wiki.sh
@@ -131,7 +131,7 @@ $body
 
 $body
 
-_last synced: $synced_at_
+_last synced: ${synced_at}_
 EOF
 
 git config user.name "$GIT_AUTHOR_NAME"

--- a/.github/scripts/sync-merged-pr-to-wiki.sh
+++ b/.github/scripts/sync-merged-pr-to-wiki.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# GitHub Actions event payload 안의 문자열을 YAML frontmatter에 안전하게 넣기 위해
+# JSON string 형태로 escape한다. YAML은 JSON 문자열 표기를 그대로 문자열로 해석할 수 있다.
+json_string() {
+  jq -Rnr --arg value "$1" '$value | tojson'
+}
+
+# UTC 기준 sync 시각.
+now_iso() {
+  date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+: "${GITHUB_EVENT_PATH:?GITHUB_EVENT_PATH is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+: "${RAW_REL:?RAW_REL is required}"
+: "${GIT_AUTHOR_NAME:?GIT_AUTHOR_NAME is required}"
+: "${GIT_AUTHOR_EMAIL:?GIT_AUTHOR_EMAIL is required}"
+
+if [ ! -d "wiki/.git" ]; then
+  echo "ERROR: wiki repository checkout is missing at ./wiki" >&2
+  exit 1
+fi
+
+cd wiki
+
+# checkout 직후 최신 상태를 한 번 더 보장한다.
+git pull --ff-only
+
+source_repo="$GITHUB_REPOSITORY"
+repo_slug="${source_repo//\//__}"
+
+pr_number="$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")"
+title="$(jq -r '.pull_request.title // ""' "$GITHUB_EVENT_PATH")"
+url="$(jq -r '.pull_request.html_url // ""' "$GITHUB_EVENT_PATH")"
+author="$(jq -r '.pull_request.user.login // ""' "$GITHUB_EVENT_PATH")"
+base_ref="$(jq -r '.pull_request.base.ref // ""' "$GITHUB_EVENT_PATH")"
+merged_at="$(jq -r '.pull_request.merged_at // ""' "$GITHUB_EVENT_PATH")"
+body="$(jq -r '.pull_request.body // ""' "$GITHUB_EVENT_PATH")"
+
+# workflow의 job if가 이미 merge PR만 통과시키지만, 스크립트를 잘못 호출했을 때 대비 안전장치
+if [ "$(jq -r '.pull_request.merged // false' "$GITHUB_EVENT_PATH")" != "true" ]; then
+  echo "Pull request was closed without merge. Skipping."
+  exit 0
+fi
+
+if [ -z "$(printf '%s' "$body" | tr -d '[:space:]')" ]; then
+  body="내용 없음"
+fi
+
+raw_file="$RAW_REL/$repo_slug/pr-$pr_number.md"
+
+mkdir -p "$(dirname "$raw_file")"
+
+# 이벤트 재실행 등으로 이미 raw 파일이 있으면 다시 만들지 않는다.
+if [ -f "$raw_file" ]; then
+  echo "Raw file already exists: $raw_file"
+  exit 0
+fi
+
+assignees_yaml="$(jq -r '[.pull_request.assignees[]?.login] | map(tojson) | join(", ")' "$GITHUB_EVENT_PATH")"
+labels_yaml="$(jq -r '[.pull_request.labels[]?.name] | map(tojson) | join(", ")' "$GITHUB_EVENT_PATH")"
+
+assignees_md="$(
+  jq -r '
+    [.pull_request.assignees[]?.login]
+    | if length == 0 then "없음" else map("`" + . + "`") | join(", ") end
+  ' "$GITHUB_EVENT_PATH"
+)"
+
+labels_md="$(
+  jq -r '
+    [.pull_request.labels[]?.name]
+    | if length == 0 then "없음" else map("`" + . + "`") | join(", ") end
+  ' "$GITHUB_EVENT_PATH"
+)"
+
+workers_md="$(
+  jq -r '
+    [.pull_request.assignees[]?.login] as $assignees
+    | if ($assignees | length) > 0 then $assignees
+      elif (.pull_request.user.login // "") != "" then [.pull_request.user.login]
+      else ["확인 필요"]
+      end
+    | map("- `" + . + "`")
+    | join("\n")
+  ' "$GITHUB_EVENT_PATH"
+)"
+
+synced_at="$(now_iso)"
+
+cat > "$raw_file" <<EOF
+---
+source: github-pr
+repo: $(json_string "$source_repo")
+pr_number: $pr_number
+base_branch: $(json_string "$base_ref")
+merged_at: $(json_string "$merged_at")
+author: $(json_string "$author")
+assignees: [$assignees_yaml]
+labels: [$labels_yaml]
+url: $(json_string "$url")
+---
+
+# $source_repo PR #$pr_number - $title
+
+## 기본 정보
+
+- repo: \`$source_repo\`
+- PR number: \`$pr_number\`
+- title: $title
+- URL: $url
+- author: \`${author:-확인 필요}\`
+- assignees: $assignees_md
+- merged_at: \`$merged_at\`
+- base branch: \`$base_ref\`
+- labels: $labels_md
+
+## 작업자
+
+$workers_md
+
+## 작업내용
+
+$title
+
+$body
+
+## PR 본문 원문
+
+$body
+
+_last synced: $synced_at_
+EOF
+
+git config user.name "$GIT_AUTHOR_NAME"
+git config user.email "$GIT_AUTHOR_EMAIL"
+
+git add "$RAW_REL"
+
+if git diff --cached --quiet; then
+  echo "No changes to commit."
+  exit 0
+fi
+
+git commit -m "Add PR raw: $source_repo#$pr_number"
+
+if ! git push; then
+  echo "Push failed. Trying pull --rebase then push once..."
+  git pull --rebase
+  git push
+fi
+
+echo "Synced merged PR to wiki raw: $source_repo#$pr_number"

--- a/.github/workflows/sync-merged-pr-to-wiki.yml
+++ b/.github/workflows/sync-merged-pr-to-wiki.yml
@@ -1,0 +1,48 @@
+name: Sync merged PR to wiki raw
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - v2/develop
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  sync:
+    # closed 이벤트 중에서도 실제 merge된 PR만 처리한다.
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    env:
+      # PR raw 파일을 저장할 wiki 레포.
+      WIKI_REPOSITORY: forgather-app/forgather-wiki
+
+      # wiki 레포 안에서 raw PR 파일이 쌓일 위치.
+      RAW_REL: raw/status/pr
+
+      # 자동 커밋 작성자.
+      GIT_AUTHOR_NAME: forgather-pr-sync
+      GIT_AUTHOR_EMAIL: forgather48@gmail.com
+
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v4
+
+      - name: Checkout wiki repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.WIKI_REPOSITORY }}
+
+          # forgather-wiki에 contents: write 권한이 있는 별도 토큰을 secret으로 넣는다.
+          token: ${{ secrets.WIKI_PUSH_TOKEN }}
+          path: wiki
+
+      - name: Sync merged PR to wiki raw
+        shell: bash
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: ./.github/scripts/sync-merged-pr-to-wiki.sh


### PR DESCRIPTION
## 연관된 이슈

없음

## 변경 사항

- PR 머지 시 위키 레포에 자동 동기화하는 GitHub Actions 워크플로우 추가
- PR raw 파일 생성 bash 스크립트 추가

## 작업 내용

### PR → 위키 자동 동기화 워크플로우

팀 위키의 기반이 될 raw 파일 수집을 자동화하기 위해, `v2/develop`에 PR이 머지될 때 해당 PR의 메타데이터와 본문을 위키 레포(`forgather-app/forgather-wiki`)에 마크다운 파일로 저장하는 워크플로우를 추가했습니다.

**[트리거]**
- `v2/develop` 브랜치를 대상으로 한 PR이 `closed` 이벤트로 닫힐 때
- `github.event.pull_request.merged == true` 조건으로 실제 머지된 PR만 처리

**[생성 파일]**
- 저장 위치: `forgather-app/forgather-wiki` 레포의 `raw/status/pr/<repo-slug>/pr-<number>.md`
- 포함 내용: PR 번호, 제목, URL, 작성자, assignee, 라벨, 머지 시각, base 브랜치, 본문

**[스크립트 구조]**
| 파일 | 설명 |
|------|------|
| `.github/workflows/sync-merged-pr-to-wiki.yml` | 워크플로우 정의. 위키 레포 체크아웃 및 스크립트 실행 |
| `.github/scripts/sync-merged-pr-to-wiki.sh` | raw 파일 생성, 커밋, 푸시 처리 |

**[위키 레포 접근]**
위키 레포(`forgather-wiki`)에 `contents: write` 권한이 있는 별도 토큰을 `WIKI_PUSH_TOKEN` secret으로 등록해야하며,
forgather_app 조직 secret에 추가해두었습니다.