### PR TITLE
refactor: API 실패 응답 포맷 리팩터링

### DIFF
--- a/.claude/skills/test-writer/references/restassured-patterns.md
+++ b/.claude/skills/test-writer/references/restassured-patterns.md
@@ -64,14 +64,53 @@ var response = RestAssuredMockMvc.given()
 assertThat(response.statusCode()).isEqualTo(204);
 ```
 
-## 인증 없는 요청 테스트
+## 실패 응답 검증
+
+모든 4xx/5xx 응답은 `{code, message, data: null}` envelope 포맷이다. 인수 테스트에서는 `code` 키를 명시적으로 검증해 envelope 회귀를 막는다. `.extract()` 후 외부 `assertThat`으로 status를 검증하는 구식 패턴 대신 `.then()` 체이닝에 `.statusCode(...)` + `.body("code", equalTo(...))`를 함께 둔다.
 
 ```java
-var response = RestAssuredMockMvc.given()
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+```
+
+### 인증 실패 (Authorization 헤더 없음)
+
+```java
+RestAssuredMockMvc.given()
     .when()  // Authorization 헤더 없음
     .delete("/spaces/{spaceCode}", space.getCode())
     .then()
-    .extract();
-
-assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    .statusCode(HttpStatus.UNAUTHORIZED.value())
+    .body("code", equalTo("UNAUTHORIZED"));
 ```
+
+### 권한/리소스/검증 실패 (메시지 포함)
+
+도메인 메시지를 함께 검증하는 케이스. `code`는 envelope 회귀 가드, `message`는 도메인 동작 검증 역할.
+
+```java
+RestAssuredMockMvc.given()
+    .header("Authorization", "Bearer " + token)
+    .when()
+    .delete("/spaces/{spaceCode}/guestbook/{cardId}", spaceCode, cardId)
+    .then()
+    .statusCode(403)
+    .body("code", equalTo("FORBIDDEN"))
+    .body("message", containsString("해당 스페이스에 대한 접근 권한이 없습니다."));
+```
+
+### `code` 매핑 빠른 참조
+
+| HTTP | code | 비고 |
+|---|---|---|
+| 400 | `BAD_REQUEST` | `BaseException`(default), `MultipartException`, 타입 불일치 등 |
+| 400 | `VALIDATION_FAILED` | `@Valid` 실패 (`MethodArgumentNotValidException`) |
+| 401 | `UNAUTHORIZED` | `UnauthorizedException`, 세션/인증 누락 |
+| 401 | `JWT_INVALID` | `JwtException` 계열 |
+| 403 | `FORBIDDEN` | `ForbiddenException`, 권한 부족 |
+| 404 | `NOT_FOUND` | 커스텀 `NotFoundException` |
+| 404 | `RESOURCE_NOT_FOUND` | Spring `NoResourceFoundException` (정적 리소스) |
+| 409 | `CONFLICT` | `ConflictException` |
+| 5xx | `INTERNAL_ERROR` / `FILE_*_FAILED` | 메시지는 마스킹되므로 `containsString` 금지 |
+
+> 5xx는 응답 메시지가 영역별 고정 문구로 마스킹된다(`"예상치 못한 오류가 발생했습니다."` 등). 도메인 원본 메시지는 인수 테스트에서 검증할 수 없으니 `code`로만 분기한다.

--- a/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
@@ -89,8 +89,8 @@ public class GlobalExceptionHandler {
     // 컨트롤러 요청 파라미터의 타입 불일치
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchException(
-        MethodArgumentTypeMismatchException e) {
-
+        MethodArgumentTypeMismatchException e
+    ) {
         logClientWarning(e);
         String parameterName = e.getParameter().getParameterName();
         String requiredType = e.getRequiredType().getSimpleName();
@@ -173,14 +173,12 @@ public class GlobalExceptionHandler {
             logServerError(e);
         }
 
-        ResponseCode code = resolveCode(e);
-        String message = e.getStatusCode() >= INTERNAL_SERVER_ERROR.value()
-            ? maskServerMessage(code)
-            : e.getMessage();
+        ResponseCode responseCode = resolveCode(e);
+        String message = getResponseMessage(e, responseCode);
 
         return ResponseEntity.status(e.getStatusCode())
             .contentType(APPLICATION_JSON)
-            .body(ApiResponse.error(code, message));
+            .body(ApiResponse.error(responseCode, message));
     }
 
     private ResponseCode resolveCode(BaseException e) {
@@ -201,6 +199,14 @@ public class GlobalExceptionHandler {
             return ResponseCode.INTERNAL_ERROR;
         }
         return ResponseCode.BAD_REQUEST;
+    }
+
+    private String getResponseMessage(BaseException exception, ResponseCode responseCode) {
+        // 서버 에러의 경우 API 응답 메시지 마스킹
+        if (exception.getStatusCode() >= INTERNAL_SERVER_ERROR.value()) {
+            return maskServerMessage(responseCode);
+        }
+        return exception.getMessage();
     }
 
     private String maskServerMessage(ResponseCode code) {

--- a/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
@@ -17,6 +17,9 @@ import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
+import com.forgather.global.response.ApiResponse;
+import com.forgather.global.response.ResponseCode;
+
 import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,31 +33,31 @@ public class GlobalExceptionHandler {
      * 예측 가능한 클라이언트발 예외 -> info
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
         logClientInfo(e);
         return ResponseEntity.status(e.getStatusCode())
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from(e.getMessage()));
+            .body(ApiResponse.error(ResponseCode.VALIDATION_FAILED, e.getMessage()));
     }
 
     @ExceptionHandler(HttpMediaTypeNotSupportedException.class)
-    public ResponseEntity<ErrorResponse> handleHttpMediaTypeNotSupportedException(
+    public ResponseEntity<ApiResponse<Void>> handleHttpMediaTypeNotSupportedException(
         HttpMediaTypeNotSupportedException e
     ) {
         logClientInfo(e);
         return ResponseEntity.status(e.getStatusCode())
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from(e.getMessage()));
+            .body(ApiResponse.error(ResponseCode.UNSUPPORTED_MEDIA_TYPE, e.getMessage()));
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(
+    public ResponseEntity<ApiResponse<Void>> handleHttpRequestMethodNotSupportedException(
         HttpRequestMethodNotSupportedException e
     ) {
         logClientInfo(e);
         return ResponseEntity.status(e.getStatusCode())
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from(e.getMessage()));
+            .body(ApiResponse.error(ResponseCode.METHOD_NOT_ALLOWED, e.getMessage()));
     }
 
     @ExceptionHandler(NoResourceFoundException.class)
@@ -67,11 +70,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(MissingRequestCookieException.class)
-    public ResponseEntity<ErrorResponse> handleMissingRequestCookieException(MissingRequestCookieException e) {
+    public ResponseEntity<ApiResponse<Void>> handleMissingRequestCookieException(MissingRequestCookieException e) {
         logClientInfo(e);
         return ResponseEntity.status(e.getStatusCode())
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from("필요한 쿠키가 누락되었습니다: " + e.getCookieName()));
+            .body(ApiResponse.error(ResponseCode.MISSING_COOKIE, "필요한 쿠키가 누락되었습니다: " + e.getCookieName()));
     }
 
     @ExceptionHandler(NotFoundException.class)
@@ -84,7 +87,7 @@ public class GlobalExceptionHandler {
 
     // 컨트롤러 요청 파라미터의 타입 불일치
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchException(
         MethodArgumentTypeMismatchException e) {
 
         logClientWarning(e);
@@ -93,38 +96,41 @@ public class GlobalExceptionHandler {
         String message = String.format("파라미터 '%s'의 타입이 올바르지 않습니다. 필요한 타입: %s", parameterName, requiredType);
         return ResponseEntity.status(BAD_REQUEST)
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from(message));
+            .body(ApiResponse.error(ResponseCode.BAD_REQUEST, message));
     }
 
     // 클라이언트가 요청에 기재한 속성 존재하지 않을 경우 ex) 페이지네이션 sort 조건 속성
     // 서버에서 잘못된 코드를 작성해서 이 예외가 발생할 수도 있지만 여기까지 도달하지 않을 것이라 판단 ex) 잘못된 jpa 쿼리 메서드명
     @ExceptionHandler(PropertyReferenceException.class)
-    public ResponseEntity<ErrorResponse> handlePropertyReferenceException(PropertyReferenceException e) {
+    public ResponseEntity<ApiResponse<Void>> handlePropertyReferenceException(PropertyReferenceException e) {
         logClientWarning(e);
         String propertyName = e.getPropertyName();
         String simpleTypeName = e.getType().getType().getSimpleName();
         return ResponseEntity.status(BAD_REQUEST)
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from("'%s' 타입에 '%s' 속성이 존재하지 않습니다.".formatted(simpleTypeName, propertyName)));
+            .body(ApiResponse.error(
+                ResponseCode.BAD_REQUEST,
+                "'%s' 타입에 '%s' 속성이 존재하지 않습니다.".formatted(simpleTypeName, propertyName)
+            ));
     }
 
     /**
      * 예측 가능하지만 주의해야할 예외 -> warn
      */
     @ExceptionHandler(MultipartException.class)
-    public ResponseEntity<ErrorResponse> handleMultipartException(MultipartException e) {
+    public ResponseEntity<ApiResponse<Void>> handleMultipartException(MultipartException e) {
         logClientWarning(e);
         return ResponseEntity.status(BAD_REQUEST)
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from(e.getMessage()));
+            .body(ApiResponse.error(ResponseCode.BAD_REQUEST, e.getMessage()));
     }
 
     @ExceptionHandler(MaxUploadSizeExceededException.class)
-    public ResponseEntity<ErrorResponse> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+    public ResponseEntity<ApiResponse<Void>> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
         logClientWarning(e);
         return ResponseEntity.status(e.getStatusCode())
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from(e.getMessage()));
+            .body(ApiResponse.error(ResponseCode.PAYLOAD_TOO_LARGE, e.getMessage()));
     }
 
     @ExceptionHandler(JwtException.class)

--- a/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
@@ -173,9 +173,14 @@ public class GlobalExceptionHandler {
             logServerError(e);
         }
 
+        ResponseCode code = resolveCode(e);
+        String message = e.getStatusCode() >= INTERNAL_SERVER_ERROR.value()
+            ? maskServerMessage(code)
+            : e.getMessage();
+
         return ResponseEntity.status(e.getStatusCode())
             .contentType(APPLICATION_JSON)
-            .body(ApiResponse.error(resolveCode(e), e.getMessage()));
+            .body(ApiResponse.error(code, message));
     }
 
     private ResponseCode resolveCode(BaseException e) {
@@ -198,6 +203,14 @@ public class GlobalExceptionHandler {
         return ResponseCode.BAD_REQUEST;
     }
 
+    private String maskServerMessage(ResponseCode code) {
+        return switch (code) {
+            case FILE_UPLOAD_FAILED -> "파일 업로드 처리 중 오류가 발생했습니다.";
+            case FILE_DOWNLOAD_FAILED -> "파일 다운로드 처리 중 오류가 발생했습니다.";
+            default -> "예상치 못한 오류가 발생했습니다.";
+        };
+    }
+
     private void logClientInfo(Exception e) {
         log.atInfo().log("{}: {}", e.getClass().getSimpleName(), e.getMessage());
     }
@@ -208,22 +221,18 @@ public class GlobalExceptionHandler {
 
     /**
      * 핸들링 되지 않은 모든 예외 -> error
+     * 원본 메시지는 내부 정보(스키마/경로/라이브러리 내부 구조 등) 유출 우려가 있어 응답에서는 마스킹하고
+     * 추적은 logServerError가 남기는 stack trace로 수행한다.
      */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+    public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
         logServerError(e);
         return ResponseEntity.internalServerError()
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from(e.getMessage()));
+            .body(ApiResponse.error(ResponseCode.INTERNAL_ERROR, "예상치 못한 오류가 발생했습니다."));
     }
 
     private void logServerError(Exception e) {
         log.atError().setCause(e).log("{}: {}", e.getClass().getSimpleName(), e.getMessage());
-    }
-
-    public record ErrorResponse(String message) {
-        public static ErrorResponse from(String message) {
-            return new ErrorResponse(message);
-        }
     }
 }

--- a/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
@@ -61,12 +61,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(NoResourceFoundException.class)
-    public ResponseEntity<ErrorResponse> handleNoResourceFoundException(NoResourceFoundException e) {
+    public ResponseEntity<ApiResponse<Void>> handleNoResourceFoundException(NoResourceFoundException e) {
         logClientInfo(e);
-        var errorResponse = ErrorResponse.from(e.getMessage());
         return ResponseEntity.status(e.getStatusCode())
             .contentType(APPLICATION_JSON)
-            .body(errorResponse);
+            .body(ApiResponse.error(ResponseCode.RESOURCE_NOT_FOUND, e.getMessage()));
     }
 
     @ExceptionHandler(MissingRequestCookieException.class)
@@ -78,11 +77,11 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<ErrorResponse> handleNotFoundException(NotFoundException e) {
+    public ResponseEntity<ApiResponse<Void>> handleNotFoundException(NotFoundException e) {
         logClientInfo(e);
         return ResponseEntity.status(e.getStatusCode())
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from(e.getMessage()));
+            .body(ApiResponse.error(ResponseCode.NOT_FOUND, e.getMessage()));
     }
 
     // 컨트롤러 요청 파라미터의 타입 불일치

--- a/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
@@ -134,27 +134,27 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(JwtException.class)
-    public ResponseEntity<ErrorResponse> handleJwtException(JwtException e) {
+    public ResponseEntity<ApiResponse<Void>> handleJwtException(JwtException e) {
         logClientWarning(e);
         return ResponseEntity.status(UNAUTHORIZED)
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from(e.getMessage()));
+            .body(ApiResponse.error(ResponseCode.JWT_INVALID, e.getMessage()));
     }
 
     @ExceptionHandler(ForbiddenException.class)
-    public ResponseEntity<ErrorResponse> handleForbiddenException(ForbiddenException e) {
+    public ResponseEntity<ApiResponse<Void>> handleForbiddenException(ForbiddenException e) {
         logClientWarning(e);
         return ResponseEntity.status(e.getStatusCode())
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from(e.getMessage()));
+            .body(ApiResponse.error(ResponseCode.FORBIDDEN, e.getMessage()));
     }
 
     @ExceptionHandler(UnauthorizedException.class)
-    public ResponseEntity<ErrorResponse> handleUnauthorizedException(UnauthorizedException e) {
+    public ResponseEntity<ApiResponse<Void>> handleUnauthorizedException(UnauthorizedException e) {
         logClientWarning(e);
         return ResponseEntity.status(e.getStatusCode())
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from(e.getMessage()));
+            .body(ApiResponse.error(ResponseCode.UNAUTHORIZED, e.getMessage()));
     }
 
     /**

--- a/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
@@ -1,12 +1,12 @@
 package com.forgather.global.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
 import org.springframework.data.mapping.PropertyReferenceException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -192,13 +192,27 @@ public class GlobalExceptionHandler {
             return ResponseCode.FILE_DOWNLOAD_FAILED;
         }
         int status = e.getStatusCode();
-        if (status == CONFLICT.value()) {
-            return ResponseCode.CONFLICT;
-        }
         if (status >= INTERNAL_SERVER_ERROR.value()) {
             return ResponseCode.INTERNAL_ERROR;
         }
-        return ResponseCode.BAD_REQUEST;
+        return resolveClientErrorCode(status);
+    }
+
+    /**
+     * BaseException(message, HttpStatus) 형태로 4xx status를 직접 받은 경로에서
+     * isSecurityError() 등 status 기반 판단과 응답 code가 어긋나지 않도록 분기
+     */
+    private ResponseCode resolveClientErrorCode(int status) {
+        return switch (HttpStatus.valueOf(status)) {
+            case UNAUTHORIZED -> ResponseCode.UNAUTHORIZED;
+            case FORBIDDEN -> ResponseCode.FORBIDDEN;
+            case NOT_FOUND -> ResponseCode.NOT_FOUND;
+            case METHOD_NOT_ALLOWED -> ResponseCode.METHOD_NOT_ALLOWED;
+            case CONFLICT -> ResponseCode.CONFLICT;
+            case PAYLOAD_TOO_LARGE -> ResponseCode.PAYLOAD_TOO_LARGE;
+            case UNSUPPORTED_MEDIA_TYPE -> ResponseCode.UNSUPPORTED_MEDIA_TYPE;
+            default -> ResponseCode.BAD_REQUEST;
+        };
     }
 
     private String getResponseMessage(BaseException exception, ResponseCode responseCode) {

--- a/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/forgather/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.forgather.global.exception;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 
@@ -162,7 +164,7 @@ public class GlobalExceptionHandler {
      * 5XX -> error
      */
     @ExceptionHandler(BaseException.class)
-    public ResponseEntity<ErrorResponse> handleBaseException(BaseException e) {
+    public ResponseEntity<ApiResponse<Void>> handleBaseException(BaseException e) {
         if (e.isSecurityError()) {
             logClientWarning(e);
         } else if (e.isClientError()) {
@@ -173,7 +175,27 @@ public class GlobalExceptionHandler {
 
         return ResponseEntity.status(e.getStatusCode())
             .contentType(APPLICATION_JSON)
-            .body(ErrorResponse.from(e.getMessage()));
+            .body(ApiResponse.error(resolveCode(e), e.getMessage()));
+    }
+
+    private ResponseCode resolveCode(BaseException e) {
+        if (e instanceof JwtBaseException) {
+            return ResponseCode.JWT_INVALID;
+        }
+        if (e instanceof FileUploadException) {
+            return ResponseCode.FILE_UPLOAD_FAILED;
+        }
+        if (e instanceof FileDownloadException) {
+            return ResponseCode.FILE_DOWNLOAD_FAILED;
+        }
+        int status = e.getStatusCode();
+        if (status == CONFLICT.value()) {
+            return ResponseCode.CONFLICT;
+        }
+        if (status >= INTERNAL_SERVER_ERROR.value()) {
+            return ResponseCode.INTERNAL_ERROR;
+        }
+        return ResponseCode.BAD_REQUEST;
     }
 
     private void logClientInfo(Exception e) {

--- a/src/main/java/com/forgather/global/response/ApiResponse.java
+++ b/src/main/java/com/forgather/global/response/ApiResponse.java
@@ -17,4 +17,8 @@ public record ApiResponse<T>(
     public static <T> ApiResponse<T> success(String message, T data) {
         return new ApiResponse<>(ResponseCode.SUCCESS, message, data);
     }
+
+    public static ApiResponse<Void> error(ResponseCode code, String message) {
+        return new ApiResponse<>(code, message, null);
+    }
 }

--- a/src/main/java/com/forgather/global/response/ResponseCode.java
+++ b/src/main/java/com/forgather/global/response/ResponseCode.java
@@ -16,5 +16,9 @@ public enum ResponseCode {
     UNAUTHORIZED,
     FORBIDDEN,
     JWT_INVALID,
+
+    // 리소스 응답
+    NOT_FOUND,
+    RESOURCE_NOT_FOUND,
     ;
 }

--- a/src/main/java/com/forgather/global/response/ResponseCode.java
+++ b/src/main/java/com/forgather/global/response/ResponseCode.java
@@ -20,5 +20,13 @@ public enum ResponseCode {
     // 리소스 응답
     NOT_FOUND,
     RESOURCE_NOT_FOUND,
+    CONFLICT,
+
+    // 파일 처리 응답
+    FILE_UPLOAD_FAILED,
+    FILE_DOWNLOAD_FAILED,
+
+    // 서버 오류 응답
+    INTERNAL_ERROR,
     ;
 }

--- a/src/main/java/com/forgather/global/response/ResponseCode.java
+++ b/src/main/java/com/forgather/global/response/ResponseCode.java
@@ -11,5 +11,10 @@ public enum ResponseCode {
     UNSUPPORTED_MEDIA_TYPE,
     MISSING_COOKIE,
     PAYLOAD_TOO_LARGE,
+
+    // 인증/인가 응답
+    UNAUTHORIZED,
+    FORBIDDEN,
+    JWT_INVALID,
     ;
 }

--- a/src/main/java/com/forgather/global/response/ResponseCode.java
+++ b/src/main/java/com/forgather/global/response/ResponseCode.java
@@ -1,7 +1,15 @@
 package com.forgather.global.response;
 
 public enum ResponseCode {
-
+    // 성공 응답
     SUCCESS,
+
+    // 요청 오류 응답
+    BAD_REQUEST,
+    VALIDATION_FAILED,
+    METHOD_NOT_ALLOWED,
+    UNSUPPORTED_MEDIA_TYPE,
+    MISSING_COOKIE,
+    PAYLOAD_TOO_LARGE,
     ;
 }

--- a/src/test/java/com/forgather/acceptance/AdminHostAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/AdminHostAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.forgather.acceptance;
 
 import static com.forgather.back_office.auth.session.SessionConstants.SESSION_COOKIE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -102,15 +103,13 @@ class AdminHostAcceptanceTest extends AcceptanceTest {
     @DisplayName("세션이 없으면 모든 호스트 정보를 조회할 수 없다.")
     @Test
     void getAllHostsWithoutSession() {
-        // when
-        var result = RestAssuredMockMvc.given()
+        // when & then
+        RestAssuredMockMvc.given()
             .when()
             .get("/admin/hosts")
             .then()
-            .extract();
-
-        // then
-        assertThat(result.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+            .statusCode(HttpStatus.UNAUTHORIZED.value())
+            .body("code", equalTo("UNAUTHORIZED"));
     }
 
     @DisplayName("호스트가 소유한 스페이스 목록을 조회한다.")
@@ -147,15 +146,13 @@ class AdminHostAcceptanceTest extends AcceptanceTest {
         // given
         Host host = hostRepository.save(HostFixture.createHost());
 
-        // when
-        var result = RestAssuredMockMvc.given()
+        // when & then
+        RestAssuredMockMvc.given()
             .when()
             .get("/admin/hosts/{hostId}/spaces", host.getId())
             .then()
-            .extract();
-
-        // then
-        assertThat(result.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+            .statusCode(HttpStatus.UNAUTHORIZED.value())
+            .body("code", equalTo("UNAUTHORIZED"));
     }
 
     @DisplayName("호스트 이름으로 검색한다. (완전 일치)")
@@ -315,16 +312,14 @@ class AdminHostAcceptanceTest extends AcceptanceTest {
     @DisplayName("세션이 없으면 호스트 이름으로 검색할 수 없다.")
     @Test
     void searchHostsByNameWithoutSession() {
-        // when
-        var result = RestAssuredMockMvc.given()
+        // when & then
+        RestAssuredMockMvc.given()
             .queryParam("name", "포스티")
             .when()
             .get("/admin/hosts/search/by-name")
             .then()
-            .extract();
-
-        // then
-        assertThat(result.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+            .statusCode(HttpStatus.UNAUTHORIZED.value())
+            .body("code", equalTo("UNAUTHORIZED"));
     }
 
     private void createHost(int count) {

--- a/src/test/java/com/forgather/acceptance/AdminSecurityAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/AdminSecurityAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.forgather.acceptance;
 
 import static com.forgather.back_office.auth.session.SessionConstants.SESSION_COOKIE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
 
@@ -125,14 +126,12 @@ class AdminSecurityAcceptanceTest extends AcceptanceTest {
     @DisplayName("세션이 없으면 보안 요약 정보를 조회할 수 없다.")
     @Test
     void getSummaryWithoutSession() {
-        // when
-        var result = RestAssuredMockMvc.given()
+        // when & then
+        RestAssuredMockMvc.given()
             .when()
             .get("/admin/security/summary")
             .then()
-            .extract();
-
-        // then
-        assertThat(result.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+            .statusCode(HttpStatus.UNAUTHORIZED.value())
+            .body("code", equalTo("UNAUTHORIZED"));
     }
 }

--- a/src/test/java/com/forgather/acceptance/AdminSpaceAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/AdminSpaceAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.forgather.acceptance;
 
 import static com.forgather.back_office.auth.session.SessionConstants.SESSION_COOKIE_NAME;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -122,15 +123,13 @@ class AdminSpaceAcceptanceTest extends AcceptanceTest {
         // given
         createSpaces(16);
 
-        // when
-        var result = RestAssuredMockMvc.given()
+        // when & then
+        RestAssuredMockMvc.given()
             .when()
             .get("/admin/spaces")
             .then()
-            .extract();
-
-        // then
-        assertThat(result.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+            .statusCode(HttpStatus.UNAUTHORIZED.value())
+            .body("code", equalTo("UNAUTHORIZED"));
     }
 
     @DisplayName("스페이스를 상세 조회한다.")
@@ -220,15 +219,13 @@ class AdminSpaceAcceptanceTest extends AcceptanceTest {
         Space space = spaceRepository.save(SpaceFixture.createSpaceWithCode("1234567890"));
         spaceHostMapRepository.save(new SpaceHostMap(space, host));
 
-        // when
-        var result = RestAssuredMockMvc.given()
+        // when & then
+        RestAssuredMockMvc.given()
             .when()
             .get("/admin/spaces/{spaceCode}", space.getCode())
             .then()
-            .extract();
-
-        // then
-        assertThat(result.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+            .statusCode(HttpStatus.UNAUTHORIZED.value())
+            .body("code", equalTo("UNAUTHORIZED"));
     }
 
     @DisplayName("작품 소개가 등록된 모든 스페이스를 조회한다.")
@@ -290,16 +287,14 @@ class AdminSpaceAcceptanceTest extends AcceptanceTest {
     @DisplayName("세션이 없으면 필터링된 스페이스 목록을 조회할 수 없다.")
     @Test
     void getSpacesByFilterWithoutSession() {
-        // when
-        var result = RestAssuredMockMvc.given()
+        // when & then
+        RestAssuredMockMvc.given()
             .queryParam("hasProduct", true)
             .when()
             .get("/admin/spaces/search")
             .then()
-            .extract();
-
-        // then
-        assertThat(result.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+            .statusCode(HttpStatus.UNAUTHORIZED.value())
+            .body("code", equalTo("UNAUTHORIZED"));
     }
 
     @DisplayName("스페이스 이름으로 검색한다. (완전 일치)")

--- a/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.forgather.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.time.LocalDateTime;
@@ -216,6 +217,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .get("/spaces/%s/guestbook".formatted(privateSpace.getCode()))
                 .then()
                 .statusCode(403)
+                .body("code", equalTo("FORBIDDEN"))
                 .body("message", containsString("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다."));
         }
 
@@ -251,6 +253,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .get("/spaces/%s/guestbook".formatted(privateSpace.getCode()))
                 .then()
                 .statusCode(403)
+                .body("code", equalTo("FORBIDDEN"))
                 .body("message", containsString("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다."));
         }
 
@@ -337,6 +340,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .get("/spaces/%s/guestbook/%d".formatted(privateSpace.getCode(), writeResponse.id()))
                 .then()
                 .statusCode(403)
+                .body("code", equalTo("FORBIDDEN"))
                 .body("message", containsString("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다."));
         }
 
@@ -354,6 +358,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .get("/spaces/%s/guestbook/%d".formatted(privateSpace.getCode(), writeResponse.id()))
                 .then()
                 .statusCode(403)
+                .body("code", equalTo("FORBIDDEN"))
                 .body("message", containsString("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다."));
         }
 
@@ -468,6 +473,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .post("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
                 .then()
                 .statusCode(400)
+                .body("code", equalTo("BAD_REQUEST"))
                 .body("message", containsString("방문자 닉네임은 최대 10자까지 입력 가능합니다."));
         }
 
@@ -493,6 +499,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .post("/spaces/%s/guestbook".formatted(publicSpace.getCode()))
                 .then()
                 .statusCode(400)
+                .body("code", equalTo("BAD_REQUEST"))
                 .body("message", containsString("방명록 카드 사진은 최대"));
         }
     }
@@ -520,7 +527,8 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .when()
                 .get("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
                 .then()
-                .statusCode(404);
+                .statusCode(404)
+                .body("code", equalTo("NOT_FOUND"));
         }
 
         @DisplayName("방문자는 방명록 카드를 삭제하지 못한다")
@@ -535,6 +543,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .delete("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
                 .then()
                 .statusCode(401)
+                .body("code", equalTo("UNAUTHORIZED"))
                 .body("message", containsString("로그인이 필요합니다."));
         }
 
@@ -551,6 +560,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .delete("/spaces/%s/guestbook/%d".formatted(publicSpace.getCode(), writeResponse.id()))
                 .then()
                 .statusCode(403)
+                .body("code", equalTo("FORBIDDEN"))
                 .body("message", containsString("해당 스페이스에 대한 접근 권한이 없습니다."));
         }
 
@@ -567,6 +577,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .delete("/spaces/%s/guestbook/%d".formatted(privateSpace.getCode(), writeResponse.id()))
                 .then()
                 .statusCode(404)
+                .body("code", equalTo("NOT_FOUND"))
                 .body("message", containsString("해당 스페이스에 존재하지 않는 방명록 카드입니다."));
         }
     }
@@ -635,6 +646,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .delete("/spaces/%s/guestbook/%d/photos".formatted(publicSpace.getCode(), writeResponse.id()))
                 .then()
                 .statusCode(401)
+                .body("code", equalTo("UNAUTHORIZED"))
                 .body("message", containsString("로그인이 필요합니다."));
         }
 
@@ -659,6 +671,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .delete("/spaces/%s/guestbook/%d/photos".formatted(publicSpace.getCode(), writeResponse.id()))
                 .then()
                 .statusCode(403)
+                .body("code", equalTo("FORBIDDEN"))
                 .body("message", containsString("해당 스페이스에 대한 접근 권한이 없습니다."));
         }
 
@@ -682,6 +695,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .delete("/spaces/%s/guestbook/%d/photos".formatted(publicSpace.getCode(), writeResponse.id()))
                 .then()
                 .statusCode(400)
+                .body("code", equalTo("BAD_REQUEST"))
                 .body("message", containsString("해당 방명록 카드에 존재하지 않는 사진입니다."));
         }
     }

--- a/src/test/java/com/forgather/acceptance/GuestbookReportAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/GuestbookReportAcceptanceTest.java
@@ -4,6 +4,7 @@ import static com.forgather.fixture.GuestBookReportReasonFixture.createReason;
 import static com.forgather.fixture.HostFixture.createHost;
 import static com.forgather.fixture.SpaceFixture.createSpace;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -157,7 +158,8 @@ class GuestbookReportAcceptanceTest extends AcceptanceTest {
                 .post("/spaces/{spaceCode}/guestbook/{cardId}/reports",
                     space.getCode(), card.getId())
                 .then()
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .body("code", equalTo("UNAUTHORIZED"));
         }
 
         @DisplayName("스페이스 소유자가 아니면 신고할 수 없다")
@@ -175,7 +177,8 @@ class GuestbookReportAcceptanceTest extends AcceptanceTest {
                 .post("/spaces/{spaceCode}/guestbook/{cardId}/reports",
                     space.getCode(), card.getId())
                 .then()
-                .statusCode(HttpStatus.FORBIDDEN.value());
+                .statusCode(HttpStatus.FORBIDDEN.value())
+                .body("code", equalTo("FORBIDDEN"));
         }
 
         @DisplayName("해당 스페이스의 방명록이 아니면 신고할 수 없다")
@@ -196,7 +199,8 @@ class GuestbookReportAcceptanceTest extends AcceptanceTest {
                 .post("/spaces/{spaceCode}/guestbook/{cardId}/reports",
                     space.getCode(), anotherCard.getId())
                 .then()
-                .statusCode(HttpStatus.NOT_FOUND.value());
+                .statusCode(HttpStatus.NOT_FOUND.value())
+                .body("code", equalTo("NOT_FOUND"));
         }
 
         @DisplayName("이미 신고된 방명록은 재신고할 수 없다")
@@ -221,7 +225,8 @@ class GuestbookReportAcceptanceTest extends AcceptanceTest {
                 .post("/spaces/{spaceCode}/guestbook/{cardId}/reports",
                     space.getCode(), card.getId())
                 .then()
-                .statusCode(HttpStatus.CONFLICT.value());
+                .statusCode(HttpStatus.CONFLICT.value())
+                .body("code", equalTo("CONFLICT"));
         }
 
         @DisplayName("존재하지 않는 신고 사유로는 신고할 수 없다")
@@ -239,7 +244,8 @@ class GuestbookReportAcceptanceTest extends AcceptanceTest {
                 .post("/spaces/{spaceCode}/guestbook/{cardId}/reports",
                     space.getCode(), card.getId())
                 .then()
-                .statusCode(HttpStatus.NOT_FOUND.value());
+                .statusCode(HttpStatus.NOT_FOUND.value())
+                .body("code", equalTo("NOT_FOUND"));
         }
     }
 
@@ -314,7 +320,8 @@ class GuestbookReportAcceptanceTest extends AcceptanceTest {
                 .when()
                 .get("/guestbook/me/reports")
                 .then()
-                .statusCode(HttpStatus.UNAUTHORIZED.value());
+                .statusCode(HttpStatus.UNAUTHORIZED.value())
+                .body("code", equalTo("UNAUTHORIZED"));
         }
     }
 
@@ -333,6 +340,7 @@ class GuestbookReportAcceptanceTest extends AcceptanceTest {
             .post("/spaces/{spaceCode}/guestbook/{cardId}/reports",
                 space.getCode(), card.getId())
             .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value());
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .body("code", equalTo("VALIDATION_FAILED"));
     }
 }

--- a/src/test/java/com/forgather/acceptance/ProductAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/ProductAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.forgather.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
@@ -222,6 +223,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 .get("/spaces/%s/products/%d".formatted(space.getCode(), 1L))
                 .then()
                 .statusCode(404)
+                .body("code", equalTo("NOT_FOUND"))
                 .body("message", containsString("해당 스페이스에 존재하지 않는 작품입니다"));
         }
     }
@@ -313,6 +315,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 .post("/spaces/%s/products".formatted(space.getCode()))
                 .then()
                 .statusCode(400)
+                .body("code", equalTo("BAD_REQUEST"))
                 .body("message", containsString("작품은 3개까지만 등록 가능"));
         }
 
@@ -355,6 +358,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 .post("/spaces/%s/products".formatted(space.getCode()))
                 .then()
                 .statusCode(401)
+                .body("code", equalTo("UNAUTHORIZED"))
                 .body("message", containsString("로그인이 필요합니다."));
         }
 
@@ -372,6 +376,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 .post("/spaces/%s/products".formatted(space.getCode()))
                 .then()
                 .statusCode(403)
+                .body("code", equalTo("FORBIDDEN"))
                 .body("message", containsString("해당 스페이스에 대한 접근 권한이 없습니다."));
         }
     }
@@ -468,6 +473,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 .patch("/spaces/%s/products/%d".formatted(space.getCode(), registerResponse.id()))
                 .then()
                 .statusCode(400)
+                .body("code", equalTo("BAD_REQUEST"))
                 .body("message", containsString("작품에 존재하지 않는 사진입니다."));
         }
 
@@ -501,6 +507,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 .patch("/spaces/%s/products/%d".formatted(space.getCode(), registerResponse.id()))
                 .then()
                 .statusCode(401)
+                .body("code", equalTo("UNAUTHORIZED"))
                 .body("message", containsString("로그인이 필요합니다."));
         }
 
@@ -535,6 +542,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 .patch("/spaces/%s/products/%d".formatted(space.getCode(), registerResponse.id()))
                 .then()
                 .statusCode(403)
+                .body("code", equalTo("FORBIDDEN"))
                 .body("message", containsString("해당 스페이스에 대한 접근 권한이 없습니다."));
         }
     }
@@ -577,6 +585,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 .delete("/spaces/%s/products/%d".formatted(space.getCode(), registerResponse.id()))
                 .then()
                 .statusCode(401)
+                .body("code", equalTo("UNAUTHORIZED"))
                 .body("message", containsString("로그인이 필요합니다."));
         }
 
@@ -596,6 +605,7 @@ class ProductAcceptanceTest extends AcceptanceTest {
                 .delete("/spaces/%s/products/%d".formatted(space.getCode(), registerResponse.id()))
                 .then()
                 .statusCode(403)
+                .body("code", equalTo("FORBIDDEN"))
                 .body("message", containsString("해당 스페이스에 대한 접근 권한이 없습니다."));
         }
     }

--- a/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/SpaceAcceptanceTest.java
@@ -2,6 +2,7 @@ package com.forgather.acceptance;
 
 import static com.forgather.fixture.HostFixture.createHost;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -186,16 +187,14 @@ class SpaceAcceptanceTest extends AcceptanceTest {
                 "forgather@forgather.me")
         );
 
-        // when
-        var response = RestAssuredMockMvc.given()
+        // when & then
+        RestAssuredMockMvc.given()
             .multiPart("request", request, "application/json")
             .when()
             .post("/spaces")
             .then()
-            .extract();
-
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+            .statusCode(HttpStatus.UNAUTHORIZED.value())
+            .body("code", equalTo("UNAUTHORIZED"));
     }
 
     @DisplayName("스페이스를 상세 조회한다.")
@@ -296,15 +295,13 @@ class SpaceAcceptanceTest extends AcceptanceTest {
         spacePhotoRepository.save(SpacePhotoFixture.createSpacePhotoWithSpace(space));
         spaceHostMapRepository.save(new SpaceHostMap(space, host));
 
-        // when
-        var response = RestAssuredMockMvc.given()
+        // when & then
+        RestAssuredMockMvc.given()
             .when()
             .delete("/spaces/{spaceCode}", space.getCode())
             .then()
-            .extract();
-
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+            .statusCode(HttpStatus.UNAUTHORIZED.value())
+            .body("code", equalTo("UNAUTHORIZED"));
     }
 
     @DisplayName("스페이스의 호스트가 아니면 삭제할 수 없다.")
@@ -317,16 +314,14 @@ class SpaceAcceptanceTest extends AcceptanceTest {
         Host otherHost = hostRepository.save(createHost());
         String otherToken = jwtTokenProvider.generateAccessToken(otherHost.getId());
 
-        // when
-        var response = RestAssuredMockMvc.given()
+        // when & then
+        RestAssuredMockMvc.given()
             .header("Authorization", "Bearer " + otherToken)
             .when()
             .delete("/spaces/{spaceCode}", space.getCode())
             .then()
-            .extract();
-
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+            .statusCode(HttpStatus.FORBIDDEN.value())
+            .body("code", equalTo("FORBIDDEN"));
     }
 
     @DisplayName("스페이스를 수정한다.")
@@ -427,16 +422,14 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             "새로운 스페이스", null, null, null, null, false)
         );
 
-        // when
-        var response = RestAssuredMockMvc.given()
+        // when & then
+        RestAssuredMockMvc.given()
             .multiPart("request", request, "application/json")
             .when()
             .patch("/spaces/{spaceCode}", space.getCode())
             .then()
-            .extract();
-
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+            .statusCode(HttpStatus.UNAUTHORIZED.value())
+            .body("code", equalTo("UNAUTHORIZED"));
     }
 
     @DisplayName("스페이스의 호스트가 아니면 수정할 수 없다.")
@@ -453,17 +446,15 @@ class SpaceAcceptanceTest extends AcceptanceTest {
             "새로운 스페이스", null, null, null, null, false)
         );
 
-        // when
-        var response = RestAssuredMockMvc.given()
+        // when & then
+        RestAssuredMockMvc.given()
             .header("Authorization", "Bearer " + otherToken)
             .multiPart("request", request, "application/json")
             .when()
             .patch("/spaces/{spaceCode}", space.getCode())
             .then()
-            .extract();
-
-        // then
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+            .statusCode(HttpStatus.FORBIDDEN.value())
+            .body("code", equalTo("FORBIDDEN"));
     }
 
     @DisplayName("나의 스페이스 목록을 조회한다.")

--- a/src/test/java/com/forgather/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/forgather/global/exception/GlobalExceptionHandlerTest.java
@@ -262,6 +262,54 @@ class GlobalExceptionHandlerTest {
 
             assertEnvelope(res, 400, "BAD_REQUEST", "작품은 3개까지만 등록 가능합니다.");
         }
+
+        @DisplayName("BaseException(401) 직접 throw -> 401 / UNAUTHORIZED (status와 code 일치)")
+        @Test
+        void baseException_401() throws Exception {
+            Snapshot res = perform(new BaseException("인증이 필요합니다.", HttpStatus.UNAUTHORIZED));
+
+            assertEnvelope(res, 401, "UNAUTHORIZED", "인증이 필요합니다.");
+        }
+
+        @DisplayName("BaseException(403) 직접 throw -> 403 / FORBIDDEN (status와 code 일치)")
+        @Test
+        void baseException_403() throws Exception {
+            Snapshot res = perform(new BaseException("접근 권한이 없습니다.", HttpStatus.FORBIDDEN));
+
+            assertEnvelope(res, 403, "FORBIDDEN", "접근 권한이 없습니다.");
+        }
+
+        @DisplayName("BaseException(404) 직접 throw -> 404 / NOT_FOUND (status와 code 일치)")
+        @Test
+        void baseException_404() throws Exception {
+            Snapshot res = perform(new BaseException("리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND));
+
+            assertEnvelope(res, 404, "NOT_FOUND", "리소스를 찾을 수 없습니다.");
+        }
+
+        @DisplayName("BaseException(405) 직접 throw -> 405 / METHOD_NOT_ALLOWED")
+        @Test
+        void baseException_405() throws Exception {
+            Snapshot res = perform(new BaseException("허용되지 않은 메서드입니다.", HttpStatus.METHOD_NOT_ALLOWED));
+
+            assertEnvelope(res, 405, "METHOD_NOT_ALLOWED", "허용되지 않은 메서드입니다.");
+        }
+
+        @DisplayName("BaseException(413) 직접 throw -> 413 / PAYLOAD_TOO_LARGE")
+        @Test
+        void baseException_413() throws Exception {
+            Snapshot res = perform(new BaseException("요청 본문이 너무 큽니다.", HttpStatus.PAYLOAD_TOO_LARGE));
+
+            assertEnvelope(res, 413, "PAYLOAD_TOO_LARGE", "요청 본문이 너무 큽니다.");
+        }
+
+        @DisplayName("BaseException(415) 직접 throw -> 415 / UNSUPPORTED_MEDIA_TYPE")
+        @Test
+        void baseException_415() throws Exception {
+            Snapshot res = perform(new BaseException("지원하지 않는 미디어 타입입니다.", HttpStatus.UNSUPPORTED_MEDIA_TYPE));
+
+            assertEnvelope(res, 415, "UNSUPPORTED_MEDIA_TYPE", "지원하지 않는 미디어 타입입니다.");
+        }
     }
 
     @Nested

--- a/src/test/java/com/forgather/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/forgather/global/exception/GlobalExceptionHandlerTest.java
@@ -54,7 +54,7 @@ class GlobalExceptionHandlerTest {
     @DisplayName("Spring 표준 예외 핸들러")
     class SpringExceptionHandlers {
 
-        @DisplayName("MethodArgumentNotValidException → 400 / VALIDATION_FAILED")
+        @DisplayName("MethodArgumentNotValidException -> 400 / VALIDATION_FAILED")
         @Test
         void methodArgumentNotValid() throws Exception {
             MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
@@ -66,7 +66,7 @@ class GlobalExceptionHandlerTest {
             assertEnvelope(res, 400, "VALIDATION_FAILED", "validation failed for field");
         }
 
-        @DisplayName("HttpMediaTypeNotSupportedException → 415 / UNSUPPORTED_MEDIA_TYPE")
+        @DisplayName("HttpMediaTypeNotSupportedException -> 415 / UNSUPPORTED_MEDIA_TYPE")
         @Test
         void httpMediaTypeNotSupported() throws Exception {
             Snapshot res = perform(new HttpMediaTypeNotSupportedException("text/plain not supported"));
@@ -79,7 +79,7 @@ class GlobalExceptionHandlerTest {
             );
         }
 
-        @DisplayName("HttpRequestMethodNotSupportedException → 405 / METHOD_NOT_ALLOWED")
+        @DisplayName("HttpRequestMethodNotSupportedException -> 405 / METHOD_NOT_ALLOWED")
         @Test
         void httpRequestMethodNotSupported() throws Exception {
             Snapshot res = perform(new HttpRequestMethodNotSupportedException("DELETE"));
@@ -92,7 +92,7 @@ class GlobalExceptionHandlerTest {
             );
         }
 
-        @DisplayName("NoResourceFoundException → 404 / RESOURCE_NOT_FOUND")
+        @DisplayName("NoResourceFoundException -> 404 / RESOURCE_NOT_FOUND")
         @Test
         void noResourceFound() throws Exception {
             Snapshot res = perform(new NoResourceFoundException(HttpMethod.GET, "/missing"));
@@ -105,7 +105,7 @@ class GlobalExceptionHandlerTest {
             );
         }
 
-        @DisplayName("MissingRequestCookieException → 400 / MISSING_COOKIE / 가공 메시지 보존")
+        @DisplayName("MissingRequestCookieException -> 400 / MISSING_COOKIE / 가공 메시지 보존")
         @Test
         void missingRequestCookie() throws Exception {
             MethodParameter parameter = sampleParameter();
@@ -115,7 +115,7 @@ class GlobalExceptionHandlerTest {
             assertEnvelope(res, 400, "MISSING_COOKIE", "필요한 쿠키가 누락되었습니다: auth-token");
         }
 
-        @DisplayName("MethodArgumentTypeMismatchException → 400 / BAD_REQUEST / 가공 메시지 보존")
+        @DisplayName("MethodArgumentTypeMismatchException -> 400 / BAD_REQUEST / 가공 메시지 보존")
         @Test
         void methodArgumentTypeMismatch() throws Exception {
             MethodArgumentTypeMismatchException ex = new MethodArgumentTypeMismatchException(
@@ -137,7 +137,7 @@ class GlobalExceptionHandlerTest {
             );
         }
 
-        @DisplayName("PropertyReferenceException → 400 / BAD_REQUEST / 가공 메시지 보존")
+        @DisplayName("PropertyReferenceException -> 400 / BAD_REQUEST / 가공 메시지 보존")
         @Test
         void propertyReference() throws Exception {
             PropertyReferenceException ex = new PropertyReferenceException(
@@ -152,7 +152,7 @@ class GlobalExceptionHandlerTest {
                 "'SampleHolder' 타입에 'nonexistent' 속성이 존재하지 않습니다.");
         }
 
-        @DisplayName("MultipartException → 400 / BAD_REQUEST")
+        @DisplayName("MultipartException -> 400 / BAD_REQUEST")
         @Test
         void multipart() throws Exception {
             Snapshot res = perform(new MultipartException("multipart parsing failed"));
@@ -160,7 +160,7 @@ class GlobalExceptionHandlerTest {
             assertEnvelope(res, 400, "BAD_REQUEST", "multipart parsing failed");
         }
 
-        @DisplayName("MaxUploadSizeExceededException → 413 / PAYLOAD_TOO_LARGE")
+        @DisplayName("MaxUploadSizeExceededException -> 413 / PAYLOAD_TOO_LARGE")
         @Test
         void maxUploadSizeExceeded() throws Exception {
             Snapshot res = perform(new MaxUploadSizeExceededException(1024L));
@@ -172,7 +172,7 @@ class GlobalExceptionHandlerTest {
             );
         }
 
-        @DisplayName("io.jsonwebtoken.JwtException → 401 / JWT_INVALID")
+        @DisplayName("io.jsonwebtoken.JwtException -> 401 / JWT_INVALID")
         @Test
         void jwt() throws Exception {
             Snapshot res = perform(new JwtException("invalid jwt"));
@@ -185,7 +185,7 @@ class GlobalExceptionHandlerTest {
     @DisplayName("커스텀 인증/인가/리소스 예외 (별도 핸들러로 매칭, BaseException 분기에 흡수되지 않음)")
     class CustomDomainHandlers {
 
-        @DisplayName("NotFoundException → 404 / NOT_FOUND")
+        @DisplayName("NotFoundException -> 404 / NOT_FOUND")
         @Test
         void notFound() throws Exception {
             Snapshot res = perform(new NotFoundException("리소스를 찾을 수 없습니다"));
@@ -193,7 +193,7 @@ class GlobalExceptionHandlerTest {
             assertEnvelope(res, 404, "NOT_FOUND", "리소스를 찾을 수 없습니다");
         }
 
-        @DisplayName("ForbiddenException → 403 / FORBIDDEN")
+        @DisplayName("ForbiddenException -> 403 / FORBIDDEN")
         @Test
         void forbidden() throws Exception {
             Snapshot res = perform(new ForbiddenException("접근 권한이 없습니다"));
@@ -201,7 +201,7 @@ class GlobalExceptionHandlerTest {
             assertEnvelope(res, 403, "FORBIDDEN", "접근 권한이 없습니다");
         }
 
-        @DisplayName("UnauthorizedException → 401 / UNAUTHORIZED")
+        @DisplayName("UnauthorizedException -> 401 / UNAUTHORIZED")
         @Test
         void unauthorized() throws Exception {
             Snapshot res = perform(new UnauthorizedException("로그인이 필요합니다"));
@@ -214,7 +214,7 @@ class GlobalExceptionHandlerTest {
     @DisplayName("BaseException 분기 (handleBaseException + resolveCode + maskServerMessage)")
     class BaseExceptionBranch {
 
-        @DisplayName("ConflictException → 409 / CONFLICT (4xx 메시지 그대로)")
+        @DisplayName("ConflictException -> 409 / CONFLICT (4xx 메시지 그대로)")
         @Test
         void conflict() throws Exception {
             Snapshot res = perform(new ConflictException("이미 신고된 방명록입니다"));
@@ -222,7 +222,7 @@ class GlobalExceptionHandlerTest {
             assertEnvelope(res, 409, "CONFLICT", "이미 신고된 방명록입니다");
         }
 
-        @DisplayName("JwtBaseException(401) → 401 / JWT_INVALID (instanceof 우선)")
+        @DisplayName("JwtBaseException(401) -> 401 / JWT_INVALID (instanceof 우선)")
         @Test
         void jwtBase() throws Exception {
             Snapshot res = perform(new JwtParseException("토큰 파싱 실패", HttpStatus.UNAUTHORIZED));
@@ -230,7 +230,7 @@ class GlobalExceptionHandlerTest {
             assertEnvelope(res, 401, "JWT_INVALID", "토큰 파싱 실패");
         }
 
-        @DisplayName("FileUploadException(500) → 500 / FILE_UPLOAD_FAILED / 영역별 마스킹 메시지")
+        @DisplayName("FileUploadException(500) -> 500 / FILE_UPLOAD_FAILED / 영역별 마스킹 메시지")
         @Test
         void fileUpload_5xxMasked() throws Exception {
             Snapshot res = perform(new FileUploadException("S3 PutObject failed: bucket=foo key=bar"));
@@ -238,7 +238,7 @@ class GlobalExceptionHandlerTest {
             assertEnvelope(res, 500, "FILE_UPLOAD_FAILED", "파일 업로드 처리 중 오류가 발생했습니다.");
         }
 
-        @DisplayName("FileDownloadException(500) → 500 / FILE_DOWNLOAD_FAILED / 영역별 마스킹 메시지")
+        @DisplayName("FileDownloadException(500) -> 500 / FILE_DOWNLOAD_FAILED / 영역별 마스킹 메시지")
         @Test
         void fileDownload_5xxMasked() throws Exception {
             Snapshot res = perform(new FileDownloadException("S3 GetObject failed: presignedUrl=..."));
@@ -246,7 +246,7 @@ class GlobalExceptionHandlerTest {
             assertEnvelope(res, 500, "FILE_DOWNLOAD_FAILED", "파일 다운로드 처리 중 오류가 발생했습니다.");
         }
 
-        @DisplayName("BaseNullPointerException(500) → 500 / INTERNAL_ERROR / 기본 마스킹 메시지")
+        @DisplayName("BaseNullPointerException(500) -> 500 / INTERNAL_ERROR / 기본 마스킹 메시지")
         @Test
         void baseNullPointer_5xxMasked() throws Exception {
             Snapshot res = perform(
@@ -255,7 +255,7 @@ class GlobalExceptionHandlerTest {
             assertEnvelope(res, 500, "INTERNAL_ERROR", "예상치 못한 오류가 발생했습니다.");
         }
 
-        @DisplayName("BaseException 직접 throw (default 400) → 400 / BAD_REQUEST")
+        @DisplayName("BaseException 직접 throw (default 400) -> 400 / BAD_REQUEST")
         @Test
         void baseException_default400() throws Exception {
             Snapshot res = perform(new BaseException("작품은 3개까지만 등록 가능합니다."));
@@ -268,7 +268,7 @@ class GlobalExceptionHandlerTest {
     @DisplayName("Exception fallback")
     class FallbackHandler {
 
-        @DisplayName("RuntimeException → 500 / INTERNAL_ERROR / 마스킹 메시지 (원본 메시지 노출 차단)")
+        @DisplayName("RuntimeException -> 500 / INTERNAL_ERROR / 마스킹 메시지 (원본 메시지 노출 차단)")
         @Test
         void runtime_masked() throws Exception {
             Snapshot res = perform(new IllegalStateException("DB connection refused: jdbc:mysql://prod-host:3306"));

--- a/src/test/java/com/forgather/global/exception/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/forgather/global/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,328 @@
+package com.forgather.global.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.data.mapping.PropertyReferenceException;
+import org.springframework.data.util.TypeInformation;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingRequestCookieException;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.multipart.MultipartException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.JwtException;
+
+class GlobalExceptionHandlerTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ThrowingController controller = new ThrowingController();
+    private final MockMvc mockMvc = MockMvcBuilders.standaloneSetup(controller)
+        .setControllerAdvice(new GlobalExceptionHandler())
+        .build();
+
+    @BeforeEach
+    void resetController() {
+        controller.toThrow = null;
+    }
+
+    @Nested
+    @DisplayName("Spring 표준 예외 핸들러")
+    class SpringExceptionHandlers {
+
+        @DisplayName("MethodArgumentNotValidException → 400 / VALIDATION_FAILED")
+        @Test
+        void methodArgumentNotValid() throws Exception {
+            MethodArgumentNotValidException ex = mock(MethodArgumentNotValidException.class);
+            when(ex.getMessage()).thenReturn("validation failed for field");
+            when(ex.getStatusCode()).thenReturn(HttpStatusCode.valueOf(400));
+
+            Snapshot res = perform(ex);
+
+            assertEnvelope(res, 400, "VALIDATION_FAILED", "validation failed for field");
+        }
+
+        @DisplayName("HttpMediaTypeNotSupportedException → 415 / UNSUPPORTED_MEDIA_TYPE")
+        @Test
+        void httpMediaTypeNotSupported() throws Exception {
+            Snapshot res = perform(new HttpMediaTypeNotSupportedException("text/plain not supported"));
+
+            assertAll(
+                () -> assertThat(res.status).isEqualTo(415),
+                () -> assertThat(res.code).isEqualTo("UNSUPPORTED_MEDIA_TYPE"),
+                () -> assertThat(res.message).contains("text/plain not supported"),
+                () -> assertThat(res.dataIsNull).isTrue()
+            );
+        }
+
+        @DisplayName("HttpRequestMethodNotSupportedException → 405 / METHOD_NOT_ALLOWED")
+        @Test
+        void httpRequestMethodNotSupported() throws Exception {
+            Snapshot res = perform(new HttpRequestMethodNotSupportedException("DELETE"));
+
+            assertAll(
+                () -> assertThat(res.status).isEqualTo(405),
+                () -> assertThat(res.code).isEqualTo("METHOD_NOT_ALLOWED"),
+                () -> assertThat(res.message).contains("DELETE"),
+                () -> assertThat(res.dataIsNull).isTrue()
+            );
+        }
+
+        @DisplayName("NoResourceFoundException → 404 / RESOURCE_NOT_FOUND")
+        @Test
+        void noResourceFound() throws Exception {
+            Snapshot res = perform(new NoResourceFoundException(HttpMethod.GET, "/missing"));
+
+            assertAll(
+                () -> assertThat(res.status).isEqualTo(404),
+                () -> assertThat(res.code).isEqualTo("RESOURCE_NOT_FOUND"),
+                () -> assertThat(res.message).contains("/missing"),
+                () -> assertThat(res.dataIsNull).isTrue()
+            );
+        }
+
+        @DisplayName("MissingRequestCookieException → 400 / MISSING_COOKIE / 가공 메시지 보존")
+        @Test
+        void missingRequestCookie() throws Exception {
+            MethodParameter parameter = sampleParameter();
+
+            Snapshot res = perform(new MissingRequestCookieException("auth-token", parameter));
+
+            assertEnvelope(res, 400, "MISSING_COOKIE", "필요한 쿠키가 누락되었습니다: auth-token");
+        }
+
+        @DisplayName("MethodArgumentTypeMismatchException → 400 / BAD_REQUEST / 가공 메시지 보존")
+        @Test
+        void methodArgumentTypeMismatch() throws Exception {
+            MethodArgumentTypeMismatchException ex = new MethodArgumentTypeMismatchException(
+                "abc",
+                Long.class,
+                "id",
+                sampleParameter(),
+                new IllegalArgumentException("not a number")
+            );
+
+            Snapshot res = perform(ex);
+
+            // parameterName은 -parameters 컴파일 옵션 유무에 따라 id/arg0/null로 달라지므로 패턴으로 검증한다
+            assertAll(
+                () -> assertThat(res.status).isEqualTo(400),
+                () -> assertThat(res.code).isEqualTo("BAD_REQUEST"),
+                () -> assertThat(res.message).matches("파라미터 '.*'의 타입이 올바르지 않습니다\\. 필요한 타입: Long"),
+                () -> assertThat(res.dataIsNull).isTrue()
+            );
+        }
+
+        @DisplayName("PropertyReferenceException → 400 / BAD_REQUEST / 가공 메시지 보존")
+        @Test
+        void propertyReference() throws Exception {
+            PropertyReferenceException ex = new PropertyReferenceException(
+                "nonexistent",
+                TypeInformation.of(SampleHolder.class),
+                List.of()
+            );
+
+            Snapshot res = perform(ex);
+
+            assertEnvelope(res, 400, "BAD_REQUEST",
+                "'SampleHolder' 타입에 'nonexistent' 속성이 존재하지 않습니다.");
+        }
+
+        @DisplayName("MultipartException → 400 / BAD_REQUEST")
+        @Test
+        void multipart() throws Exception {
+            Snapshot res = perform(new MultipartException("multipart parsing failed"));
+
+            assertEnvelope(res, 400, "BAD_REQUEST", "multipart parsing failed");
+        }
+
+        @DisplayName("MaxUploadSizeExceededException → 413 / PAYLOAD_TOO_LARGE")
+        @Test
+        void maxUploadSizeExceeded() throws Exception {
+            Snapshot res = perform(new MaxUploadSizeExceededException(1024L));
+
+            assertAll(
+                () -> assertThat(res.status).isEqualTo(413),
+                () -> assertThat(res.code).isEqualTo("PAYLOAD_TOO_LARGE"),
+                () -> assertThat(res.dataIsNull).isTrue()
+            );
+        }
+
+        @DisplayName("io.jsonwebtoken.JwtException → 401 / JWT_INVALID")
+        @Test
+        void jwt() throws Exception {
+            Snapshot res = perform(new JwtException("invalid jwt"));
+
+            assertEnvelope(res, 401, "JWT_INVALID", "invalid jwt");
+        }
+    }
+
+    @Nested
+    @DisplayName("커스텀 인증/인가/리소스 예외 (별도 핸들러로 매칭, BaseException 분기에 흡수되지 않음)")
+    class CustomDomainHandlers {
+
+        @DisplayName("NotFoundException → 404 / NOT_FOUND")
+        @Test
+        void notFound() throws Exception {
+            Snapshot res = perform(new NotFoundException("리소스를 찾을 수 없습니다"));
+
+            assertEnvelope(res, 404, "NOT_FOUND", "리소스를 찾을 수 없습니다");
+        }
+
+        @DisplayName("ForbiddenException → 403 / FORBIDDEN")
+        @Test
+        void forbidden() throws Exception {
+            Snapshot res = perform(new ForbiddenException("접근 권한이 없습니다"));
+
+            assertEnvelope(res, 403, "FORBIDDEN", "접근 권한이 없습니다");
+        }
+
+        @DisplayName("UnauthorizedException → 401 / UNAUTHORIZED")
+        @Test
+        void unauthorized() throws Exception {
+            Snapshot res = perform(new UnauthorizedException("로그인이 필요합니다"));
+
+            assertEnvelope(res, 401, "UNAUTHORIZED", "로그인이 필요합니다");
+        }
+    }
+
+    @Nested
+    @DisplayName("BaseException 분기 (handleBaseException + resolveCode + maskServerMessage)")
+    class BaseExceptionBranch {
+
+        @DisplayName("ConflictException → 409 / CONFLICT (4xx 메시지 그대로)")
+        @Test
+        void conflict() throws Exception {
+            Snapshot res = perform(new ConflictException("이미 신고된 방명록입니다"));
+
+            assertEnvelope(res, 409, "CONFLICT", "이미 신고된 방명록입니다");
+        }
+
+        @DisplayName("JwtBaseException(401) → 401 / JWT_INVALID (instanceof 우선)")
+        @Test
+        void jwtBase() throws Exception {
+            Snapshot res = perform(new JwtParseException("토큰 파싱 실패", HttpStatus.UNAUTHORIZED));
+
+            assertEnvelope(res, 401, "JWT_INVALID", "토큰 파싱 실패");
+        }
+
+        @DisplayName("FileUploadException(500) → 500 / FILE_UPLOAD_FAILED / 영역별 마스킹 메시지")
+        @Test
+        void fileUpload_5xxMasked() throws Exception {
+            Snapshot res = perform(new FileUploadException("S3 PutObject failed: bucket=foo key=bar"));
+
+            assertEnvelope(res, 500, "FILE_UPLOAD_FAILED", "파일 업로드 처리 중 오류가 발생했습니다.");
+        }
+
+        @DisplayName("FileDownloadException(500) → 500 / FILE_DOWNLOAD_FAILED / 영역별 마스킹 메시지")
+        @Test
+        void fileDownload_5xxMasked() throws Exception {
+            Snapshot res = perform(new FileDownloadException("S3 GetObject failed: presignedUrl=..."));
+
+            assertEnvelope(res, 500, "FILE_DOWNLOAD_FAILED", "파일 다운로드 처리 중 오류가 발생했습니다.");
+        }
+
+        @DisplayName("BaseNullPointerException(500) → 500 / INTERNAL_ERROR / 기본 마스킹 메시지")
+        @Test
+        void baseNullPointer_5xxMasked() throws Exception {
+            Snapshot res = perform(
+                new BaseNullPointerException("Cannot invoke User.getId() because this.user is null"));
+
+            assertEnvelope(res, 500, "INTERNAL_ERROR", "예상치 못한 오류가 발생했습니다.");
+        }
+
+        @DisplayName("BaseException 직접 throw (default 400) → 400 / BAD_REQUEST")
+        @Test
+        void baseException_default400() throws Exception {
+            Snapshot res = perform(new BaseException("작품은 3개까지만 등록 가능합니다."));
+
+            assertEnvelope(res, 400, "BAD_REQUEST", "작품은 3개까지만 등록 가능합니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("Exception fallback")
+    class FallbackHandler {
+
+        @DisplayName("RuntimeException → 500 / INTERNAL_ERROR / 마스킹 메시지 (원본 메시지 노출 차단)")
+        @Test
+        void runtime_masked() throws Exception {
+            Snapshot res = perform(new IllegalStateException("DB connection refused: jdbc:mysql://prod-host:3306"));
+
+            assertAll(
+                () -> assertThat(res.status).isEqualTo(500),
+                () -> assertThat(res.code).isEqualTo("INTERNAL_ERROR"),
+                () -> assertThat(res.message).isEqualTo("예상치 못한 오류가 발생했습니다."),
+                () -> assertThat(res.message).doesNotContain("jdbc:mysql"),
+                () -> assertThat(res.dataIsNull).isTrue()
+            );
+        }
+    }
+
+    private Snapshot perform(Exception toThrow) throws Exception {
+        controller.toThrow = toThrow;
+        MvcResult mvc = mockMvc.perform(get("/throw")).andReturn();
+        JsonNode node = objectMapper.readTree(mvc.getResponse().getContentAsString());
+        return new Snapshot(
+            mvc.getResponse().getStatus(),
+            node.get("code").asText(),
+            node.get("message").asText(),
+            node.get("data").isNull()
+        );
+    }
+
+    private void assertEnvelope(Snapshot res, int status, String code, String message) {
+        assertAll(
+            () -> assertThat(res.status).isEqualTo(status),
+            () -> assertThat(res.code).isEqualTo(code),
+            () -> assertThat(res.message).isEqualTo(message),
+            () -> assertThat(res.dataIsNull).isTrue()
+        );
+    }
+
+    private MethodParameter sampleParameter() throws Exception {
+        return new MethodParameter(SampleHolder.class.getDeclaredMethod("sample", Long.class), 0);
+    }
+
+    private record Snapshot(int status, String code, String message, boolean dataIsNull) {
+    }
+
+    private static class SampleHolder {
+        public void sample(Long id) {
+        }
+    }
+
+    @RestController
+    static class ThrowingController {
+        Exception toThrow;
+
+        @GetMapping("/throw")
+        public void throwIt() throws Exception {
+            throw toThrow;
+        }
+    }
+}

--- a/src/test/java/com/forgather/global/response/ApiResponseTest.java
+++ b/src/test/java/com/forgather/global/response/ApiResponseTest.java
@@ -1,6 +1,7 @@
 package com.forgather.global.response;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -27,9 +28,11 @@ class ApiResponseTest {
             ApiResponse<String> response = ApiResponse.success(data);
 
             // then
-            assertThat(response.code()).isEqualTo(ResponseCode.SUCCESS);
-            assertThat(response.message()).isNull();
-            assertThat(response.data()).isEqualTo(data);
+            assertAll(
+                () -> assertThat(response.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(response.message()).isNull(),
+                () -> assertThat(response.data()).isEqualTo(data)
+            );
         }
 
         @DisplayName("success()는 데이터 없이 SUCCESS 코드만 담는다")
@@ -39,9 +42,11 @@ class ApiResponseTest {
             ApiResponse<Void> response = ApiResponse.success();
 
             // then
-            assertThat(response.code()).isEqualTo(ResponseCode.SUCCESS);
-            assertThat(response.message()).isNull();
-            assertThat(response.data()).isNull();
+            assertAll(
+                () -> assertThat(response.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(response.message()).isNull(),
+                () -> assertThat(response.data()).isNull()
+            );
         }
 
         @DisplayName("success(message, data)는 메시지와 데이터를 함께 담는다")
@@ -55,9 +60,28 @@ class ApiResponseTest {
             ApiResponse<Integer> response = ApiResponse.success(message, data);
 
             // then
-            assertThat(response.code()).isEqualTo(ResponseCode.SUCCESS);
-            assertThat(response.message()).isEqualTo(message);
-            assertThat(response.data()).isEqualTo(data);
+            assertAll(
+                () -> assertThat(response.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(response.message()).isEqualTo(message),
+                () -> assertThat(response.data()).isEqualTo(data)
+            );
+        }
+
+        @DisplayName("error(code, message)는 전달받은 코드와 메시지를 담고 데이터는 null이다")
+        @Test
+        void error_withCodeAndMessage() {
+            // given
+            String message = "잘못된 요청입니다";
+
+            // when
+            ApiResponse<Void> response = ApiResponse.error(ResponseCode.BAD_REQUEST, message);
+
+            // then
+            assertAll(
+                () -> assertThat(response.code()).isEqualTo(ResponseCode.BAD_REQUEST),
+                () -> assertThat(response.message()).isEqualTo(message),
+                () -> assertThat(response.data()).isNull()
+            );
         }
     }
 
@@ -89,9 +113,30 @@ class ApiResponseTest {
             JsonNode node = objectMapper.valueToTree(response);
 
             // then
-            assertThat(node.get("code").asText()).isEqualTo("SUCCESS");
-            assertThat(node.get("message").isNull()).isTrue();
-            assertThat(node.get("data").isNull()).isTrue();
+            assertAll(
+                () -> assertThat(node.get("code").asText()).isEqualTo("SUCCESS"),
+                () -> assertThat(node.get("message").isNull()).isTrue(),
+                () -> assertThat(node.get("data").isNull()).isTrue()
+            );
+        }
+
+        @DisplayName("error 응답은 code/message/data 세 필드만 갖고 code는 enum 이름 문자열, data는 null로 직렬화된다")
+        @Test
+        void serialize_errorEnvelope() {
+            // given
+            ApiResponse<Void> response = ApiResponse.error(ResponseCode.VALIDATION_FAILED, "유효하지 않은 입력입니다");
+
+            // when
+            JsonNode node = objectMapper.valueToTree(response);
+
+            // then
+            assertAll(
+                () -> assertThat(node.fieldNames()).toIterable()
+                    .containsExactlyInAnyOrder("code", "message", "data"),
+                () -> assertThat(node.get("message").asText()).isEqualTo("유효하지 않은 입력입니다"),
+                () -> assertThat(node.get("code").asText()).isEqualTo("VALIDATION_FAILED"),
+                () -> assertThat(node.get("data").isNull()).isTrue()
+            );
         }
     }
 }


### PR DESCRIPTION
## 연관된 이슈

- close #84 

## 작업 내용

- 모든 4xx/5xx 응답 본문을 `{code, message, data: null}`로 통일
- HTTP 상태 코드는 변경하지 않음
- 변환 지점은 `GlobalExceptionHandler` 한 곳으로 집중
- 비즈니스 throw 사이트(서비스/엔티티)와 도메인 예외 클래스는 무변경
- 기존 인수 테스트에 `ResponseCode` 검증을 추가. 메시지의 경우는 변경 가능성이 존재하는 상태값이고 검증이 크게 중요하지 않다고 판단해 따로 추가하지 않았습니다
- 기존 5xx 서버 에러 메시지가 클라이언트에게 그대로 노출되어 서버 에러의 경우 로깅에는 원본 예외 메시지를 추가하고, 응답은 기존 예외 메시지를 마스킹해 응답을 내려줍니다


실패(에러) 응답 형태는 아래와 같습니다.
```json
{
  "code": "NOT_FOUND",
  "message": "존재하지 않는 방명록입니다. guestbook_id: 4",
  "data": null
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 모든 예외에 대해 오류 응답 형식이 통일되어 일관된 코드와 메시지로 반환됩니다.
  * 내부 서버 에러 메시지는 마스킹되어 노출되지 않습니다.
  * 다양한 오류 상황에 대해 보다 세분화된 오류 코드(권한·인증·검증·업로드 등)가 추가되었습니다.

* **Tests**
  * 수용·단위 테스트에서 오류 응답의 코드 필드와 메시지 검증이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->