### PR TITLE
feature: 방명록 신고 내역 상세 조회

### DIFF
--- a/src/main/java/com/forgather/domain/guestbook/controller/GuestbookController.java
+++ b/src/main/java/com/forgather/domain/guestbook/controller/GuestbookController.java
@@ -58,11 +58,11 @@ public class GuestbookController {
     )
     @GetMapping("/me/reports")
     public ResponseEntity<ApiResponse<ReportHistoryResponse>> retrieveReportHistory(
-        @LoginHost(required = true) Host loginUser,
+        @LoginHost(required = true) Host loginHost,
         @PageableDefault(size = 15, sort = {"createdAt", "id"}, direction = Sort.Direction.DESC)
         Pageable pageable
     ) {
-        var response = guestBookReportService.retrieveReportHistory(loginUser, pageable);
+        var response = guestBookReportService.retrieveReportHistory(loginHost, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/forgather/domain/guestbook/controller/GuestbookController.java
+++ b/src/main/java/com/forgather/domain/guestbook/controller/GuestbookController.java
@@ -5,9 +5,11 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.forgather.domain.guestbook.dto.ReportDetailResponse;
 import com.forgather.domain.guestbook.dto.ReportHistoryResponse;
 import com.forgather.domain.guestbook.service.GuestbookReportService;
 import com.forgather.global.auth.annotation.LoginHost;
@@ -61,6 +63,18 @@ public class GuestbookController {
         Pageable pageable
     ) {
         var response = guestBookReportService.retrieveReportHistory(loginUser, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @SecurityRequirement(name = "bearerAuth")
+    @Operation(summary = "방명록 신고내역 상세 조회",
+        description = "로그인 사용자의 특정 방명록 신고 내역 상세 조회")
+    @GetMapping("/me/reports/{reportId}")
+    public ResponseEntity<ApiResponse<ReportDetailResponse>> retrieveReportDetail(
+        @LoginHost(required = true) Host loginHost,
+        @PathVariable Long reportId
+    ) {
+        var response = guestBookReportService.retrieveReportDetail(loginHost, reportId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/forgather/domain/guestbook/dto/ReportDetailResponse.java
+++ b/src/main/java/com/forgather/domain/guestbook/dto/ReportDetailResponse.java
@@ -1,0 +1,45 @@
+package com.forgather.domain.guestbook.dto;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.forgather.domain.guestbook.model.GuestBookReport;
+import com.forgather.domain.guestbook.model.GuestBookReportReason;
+import com.forgather.domain.space.model.Space;
+
+public record ReportDetailResponse(
+    Long id,
+    SpaceInfo space,
+    ReasonInfo reason,
+    String detail,
+    String nicknameSnapshot,
+    String messageSnapshot,
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    LocalDateTime createdAtSnapshot,
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    LocalDateTime createdAt
+) {
+
+    public record SpaceInfo(String spaceCode, String name) {
+    }
+
+    public record ReasonInfo(Long id, String label) {
+    }
+
+    public static ReportDetailResponse from(GuestBookReport report) {
+        Space space = report.getGuestBookCard().getSpace();
+        GuestBookReportReason reason = report.getReason();
+        return new ReportDetailResponse(
+            report.getId(),
+            new SpaceInfo(space.getCode(), space.getName()),
+            new ReasonInfo(reason.getId(), reason.getLabel()),
+            report.getDetail(),
+            report.getNicknameSnapshot(),
+            report.getMessageSnapshot(),
+            report.getCreatedAtSnapshot(),
+            report.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/forgather/domain/guestbook/model/GuestBookReport.java
+++ b/src/main/java/com/forgather/domain/guestbook/model/GuestBookReport.java
@@ -37,11 +37,11 @@ public class GuestBookReport extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "host_user_id", nullable = false)
-    private Host hostUser;
+    private Host spaceHost;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reporter_user_id", nullable = false)
-    private Host reporterUser;
+    private Host reporter;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reason_id", nullable = false)
@@ -65,17 +65,17 @@ public class GuestBookReport extends BaseTimeEntity {
 
     public GuestBookReport(
         GuestBookCard guestBookCard,
-        Host hostUser,
-        Host reporterUser,
+        Host spaceHost,
+        Host reporter,
         ReporterType reporterType,
         GuestBookReportReason reason,
         String detail
     ) {
-        validateRequiredFields(guestBookCard, hostUser, reporterUser, reporterType, reason);
+        validateRequiredFields(guestBookCard, spaceHost, reporter, reporterType, reason);
         validateDetail(detail);
         this.guestBookCard = guestBookCard;
-        this.hostUser = hostUser;
-        this.reporterUser = reporterUser;
+        this.spaceHost = spaceHost;
+        this.reporter = reporter;
         this.reason = reason;
         this.reporterType = reporterType;
         this.detail = detail;
@@ -86,18 +86,18 @@ public class GuestBookReport extends BaseTimeEntity {
 
     private void validateRequiredFields(
         GuestBookCard guestBookCard,
-        Host hostUser,
-        Host reporterUser,
+        Host spaceHost,
+        Host reporter,
         ReporterType reporterType,
         GuestBookReportReason reason
     ) {
         if (guestBookCard == null) {
             throw new BaseNullPointerException("방명록 카드는 null일 수 없습니다.");
         }
-        if (hostUser == null) {
-            throw new BaseNullPointerException("호스트는 null일 수 없습니다.");
+        if (spaceHost == null) {
+            throw new BaseNullPointerException("스페이스 호스트는 null일 수 없습니다.");
         }
-        if (reporterUser == null) {
+        if (reporter == null) {
             throw new BaseNullPointerException("신고자는 null일 수 없습니다.");
         }
         if (reporterType == null) {

--- a/src/main/java/com/forgather/domain/guestbook/model/GuestBookReport.java
+++ b/src/main/java/com/forgather/domain/guestbook/model/GuestBookReport.java
@@ -117,4 +117,8 @@ public class GuestBookReport extends BaseTimeEntity {
             throw new BaseException("상세 사유는 최소 5자, 최대 200자까지 입력 가능합니다.");
         }
     }
+
+    public boolean equalsReporter(Host other) {
+        return reporter.equals(other);
+    }
 }

--- a/src/main/java/com/forgather/domain/guestbook/repository/GuestBookReportRepository.java
+++ b/src/main/java/com/forgather/domain/guestbook/repository/GuestBookReportRepository.java
@@ -4,8 +4,6 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import com.forgather.domain.guestbook.model.GuestBookCard;
 import com.forgather.domain.guestbook.model.GuestBookReport;
@@ -21,26 +19,13 @@ public interface GuestBookReportRepository {
 
     Page<GuestBookReport> findAllByReporter(Host loginUser, Pageable pageable);
 
-    @Query("""
-        SELECT r FROM GuestBookReport r
-        JOIN FETCH r.guestBookCard c
-        JOIN FETCH c.space
-        JOIN FETCH r.reason
-        WHERE r.id = :id AND r.reporter = :reporter
-        """)
-    Optional<GuestBookReport> findByIdWithDetailsAndReporter(
-        @Param("id") Long id,
-        @Param("reporter") Host reporter
-    );
+    Optional<GuestBookReport> findById(Long id);
 
-    default GuestBookReport getByIdAndReporterOrThrow(Long id, Host reporter) {
+    default GuestBookReport getByIdOrThrow(Long id) {
         if (id == null) {
-            throw new BaseNullPointerException("신고 id는 null일 수 없습니다.");
+            throw new BaseNullPointerException("신고 내역 id는 null일 수 없습니다.");
         }
-        if (reporter == null) {
-            throw new BaseNullPointerException("신고자는 null일 수 없습니다.");
-        }
-        return findByIdWithDetailsAndReporter(id, reporter)
-            .orElseThrow(() -> new NotFoundException("존재하지 않는 신고이거나 조회 권한이 없습니다. reportId: " + id));
+        return findById(id)
+            .orElseThrow(() -> new NotFoundException("존재하지 않는 방명록 신고 내역입니다. reportId: " + id));
     }
 }

--- a/src/main/java/com/forgather/domain/guestbook/repository/GuestBookReportRepository.java
+++ b/src/main/java/com/forgather/domain/guestbook/repository/GuestBookReportRepository.java
@@ -1,11 +1,17 @@
 package com.forgather.domain.guestbook.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.forgather.domain.guestbook.model.GuestBookCard;
 import com.forgather.domain.guestbook.model.GuestBookReport;
 import com.forgather.global.auth.model.Host;
+import com.forgather.global.exception.BaseNullPointerException;
+import com.forgather.global.exception.NotFoundException;
 
 public interface GuestBookReportRepository {
 
@@ -14,4 +20,27 @@ public interface GuestBookReportRepository {
     boolean existsByGuestBookCardAndReporterUser(GuestBookCard guestBookCard, Host reporterUser);
 
     Page<GuestBookReport> findAllByReporterUser(Host loginUser, Pageable pageable);
+
+    @Query("""
+        SELECT r FROM GuestBookReport r
+        JOIN FETCH r.guestBookCard c
+        JOIN FETCH c.space
+        JOIN FETCH r.reason
+        WHERE r.id = :id AND r.reporterUser = :reporterUser
+        """)
+    Optional<GuestBookReport> findByIdWithDetailsAndReporterUser(
+        @Param("id") Long id,
+        @Param("reporterUser") Host reporter
+    );
+
+    default GuestBookReport getByIdAndReporterUserOrThrow(Long id, Host reporter) {
+        if (id == null) {
+            throw new BaseNullPointerException("신고 id는 null일 수 없습니다.");
+        }
+        if (reporter == null) {
+            throw new BaseNullPointerException("신고자는 null일 수 없습니다.");
+        }
+        return findByIdWithDetailsAndReporterUser(id, reporter)
+            .orElseThrow(() -> new NotFoundException("존재하지 않는 신고이거나 조회 권한이 없습니다. reportId: " + id));
+    }
 }

--- a/src/main/java/com/forgather/domain/guestbook/repository/GuestBookReportRepository.java
+++ b/src/main/java/com/forgather/domain/guestbook/repository/GuestBookReportRepository.java
@@ -17,30 +17,30 @@ public interface GuestBookReportRepository {
 
     GuestBookReport save(GuestBookReport report);
 
-    boolean existsByGuestBookCardAndReporterUser(GuestBookCard guestBookCard, Host reporterUser);
+    boolean existsByGuestBookCardAndReporter(GuestBookCard guestBookCard, Host reporter);
 
-    Page<GuestBookReport> findAllByReporterUser(Host loginUser, Pageable pageable);
+    Page<GuestBookReport> findAllByReporter(Host loginUser, Pageable pageable);
 
     @Query("""
         SELECT r FROM GuestBookReport r
         JOIN FETCH r.guestBookCard c
         JOIN FETCH c.space
         JOIN FETCH r.reason
-        WHERE r.id = :id AND r.reporterUser = :reporterUser
+        WHERE r.id = :id AND r.reporter = :reporter
         """)
-    Optional<GuestBookReport> findByIdWithDetailsAndReporterUser(
+    Optional<GuestBookReport> findByIdWithDetailsAndReporter(
         @Param("id") Long id,
-        @Param("reporterUser") Host reporter
+        @Param("reporter") Host reporter
     );
 
-    default GuestBookReport getByIdAndReporterUserOrThrow(Long id, Host reporter) {
+    default GuestBookReport getByIdAndReporterOrThrow(Long id, Host reporter) {
         if (id == null) {
             throw new BaseNullPointerException("신고 id는 null일 수 없습니다.");
         }
         if (reporter == null) {
             throw new BaseNullPointerException("신고자는 null일 수 없습니다.");
         }
-        return findByIdWithDetailsAndReporterUser(id, reporter)
+        return findByIdWithDetailsAndReporter(id, reporter)
             .orElseThrow(() -> new NotFoundException("존재하지 않는 신고이거나 조회 권한이 없습니다. reportId: " + id));
     }
 }

--- a/src/main/java/com/forgather/domain/guestbook/service/GuestbookReportService.java
+++ b/src/main/java/com/forgather/domain/guestbook/service/GuestbookReportService.java
@@ -37,17 +37,20 @@ public class GuestbookReportService {
     private final GuestBookReportReasonRepository guestBookReportReasonRepository;
 
     @Transactional(readOnly = true)
-    public ReportHistoryResponse retrieveReportHistory(Host host, Pageable pageable) {
+    public ReportHistoryResponse retrieveReportHistory(Host reporter, Pageable pageable) {
         Page<GuestBookReport> reports = guestBookReportRepository.findAllByReporter(
-            host,
+            reporter,
             pageable
         );
         return ReportHistoryResponse.from(reports);
     }
 
     @Transactional(readOnly = true)
-    public ReportDetailResponse retrieveReportDetail(Host loginHost, Long reportId) {
-        GuestBookReport report = guestBookReportRepository.getByIdAndReporterOrThrow(reportId, loginHost);
+    public ReportDetailResponse retrieveReportDetail(Host reporter, Long reportId) {
+        GuestBookReport report = guestBookReportRepository.getByIdOrThrow(reportId);
+        if (!report.equalsReporter(reporter)) {
+            throw new ForbiddenException("해당 신고 내역에 대한 접근 권한이 없습니다. reportId: " + report.getId());
+        }
         return ReportDetailResponse.from(report);
     }
 
@@ -64,7 +67,8 @@ public class GuestbookReportService {
         GuestBookCard card = getCardBySpace(guestBookCardId, space);
         validateAlreadyReported(host, card);  // 동일 사용자의 중복 신고 불가능
 
-        GuestBookReportReason reason = guestBookReportReasonRepository.getByIdAndIsHiddenFalseOrThrow(request.reasonId());
+        GuestBookReportReason reason = guestBookReportReasonRepository.getByIdAndIsHiddenFalseOrThrow(
+            request.reasonId());
         GuestBookReport report = guestBookReportRepository.save(
             new GuestBookReport(card, host, host, ReporterType.HOST, reason, request.detail())
         );

--- a/src/main/java/com/forgather/domain/guestbook/service/GuestbookReportService.java
+++ b/src/main/java/com/forgather/domain/guestbook/service/GuestbookReportService.java
@@ -37,9 +37,9 @@ public class GuestbookReportService {
     private final GuestBookReportReasonRepository guestBookReportReasonRepository;
 
     @Transactional(readOnly = true)
-    public ReportHistoryResponse retrieveReportHistory(Host loginUser, Pageable pageable) {
-        Page<GuestBookReport> reports = guestBookReportRepository.findAllByReporterUser(
-            loginUser,
+    public ReportHistoryResponse retrieveReportHistory(Host host, Pageable pageable) {
+        Page<GuestBookReport> reports = guestBookReportRepository.findAllByReporter(
+            host,
             pageable
         );
         return ReportHistoryResponse.from(reports);
@@ -47,7 +47,7 @@ public class GuestbookReportService {
 
     @Transactional(readOnly = true)
     public ReportDetailResponse retrieveReportDetail(Host loginHost, Long reportId) {
-        GuestBookReport report = guestBookReportRepository.getByIdAndReporterUserOrThrow(reportId, loginHost);
+        GuestBookReport report = guestBookReportRepository.getByIdAndReporterOrThrow(reportId, loginHost);
         return ReportDetailResponse.from(report);
     }
 
@@ -84,7 +84,7 @@ public class GuestbookReportService {
     }
 
     private void validateAlreadyReported(Host host, GuestBookCard card) {
-        if (guestBookReportRepository.existsByGuestBookCardAndReporterUser(card, host)) {
+        if (guestBookReportRepository.existsByGuestBookCardAndReporter(card, host)) {
             throw new ConflictException("이미 신고 접수된 방명록입니다. guestBookCardId: %d, reporterUserId: %d"
                 .formatted(card.getId(), host.getId()));
         }

--- a/src/main/java/com/forgather/domain/guestbook/service/GuestbookReportService.java
+++ b/src/main/java/com/forgather/domain/guestbook/service/GuestbookReportService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.forgather.domain.guestbook.dto.CreateGuestBookReportRequest;
 import com.forgather.domain.guestbook.dto.CreateGuestBookReportResponse;
+import com.forgather.domain.guestbook.dto.ReportDetailResponse;
 import com.forgather.domain.guestbook.dto.ReportHistoryResponse;
 import com.forgather.domain.guestbook.model.GuestBookCard;
 import com.forgather.domain.guestbook.model.GuestBookReport;
@@ -42,6 +43,12 @@ public class GuestbookReportService {
             pageable
         );
         return ReportHistoryResponse.from(reports);
+    }
+
+    @Transactional(readOnly = true)
+    public ReportDetailResponse retrieveReportDetail(Host loginHost, Long reportId) {
+        GuestBookReport report = guestBookReportRepository.getByIdAndReporterUserOrThrow(reportId, loginHost);
+        return ReportDetailResponse.from(report);
     }
 
     @Transactional

--- a/src/main/java/com/forgather/domain/space/model/Space.java
+++ b/src/main/java/com/forgather/domain/space/model/Space.java
@@ -169,15 +169,16 @@ public class Space extends SoftDeleteEntity {
     }
 
     @Override
-    public boolean equals(Object object) {
-        if (object == null || getClass() != object.getClass())
+    public boolean equals(Object o) {
+        if (o == null || !(o instanceof Space)) {
             return false;
-        Space space = (Space)object;
-        return Objects.equals(id, space.id);
+        }
+        Space space = (Space)o;
+        return id != null && Objects.equals(id, space.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(id);
+        return Space.class.hashCode();
     }
 }

--- a/src/main/java/com/forgather/global/auth/model/Host.java
+++ b/src/main/java/com/forgather/global/auth/model/Host.java
@@ -1,5 +1,7 @@
 package com.forgather.global.auth.model;
 
+import java.util.Objects;
+
 import com.forgather.domain.model.BaseTimeEntity;
 
 import jakarta.persistence.Column;
@@ -39,5 +41,18 @@ public class Host extends BaseTimeEntity {
 
     public void agreeTerms() {
         this.agreedTerms = true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass())
+            return false;
+        Host host = (Host)o;
+        return Objects.equals(id, host.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
     }
 }

--- a/src/main/java/com/forgather/global/auth/model/Host.java
+++ b/src/main/java/com/forgather/global/auth/model/Host.java
@@ -45,14 +45,14 @@ public class Host extends BaseTimeEntity {
 
     @Override
     public boolean equals(Object o) {
-        if (o == null || getClass() != o.getClass())
+        if (o == null || !(o instanceof Host))
             return false;
         Host host = (Host)o;
-        return Objects.equals(id, host.id);
+        return id != null && Objects.equals(id, host.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(id);
+        return Host.class.hashCode();
     }
 }

--- a/src/test/java/com/forgather/acceptance/GuestbookReportAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/GuestbookReportAcceptanceTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.forgather.domain.guestbook.dto.CreateGuestBookReportRequest;
 import com.forgather.domain.guestbook.dto.CreateGuestBookReportResponse;
+import com.forgather.domain.guestbook.dto.ReportDetailResponse;
 import com.forgather.domain.guestbook.dto.ReportHistoryResponse;
 import com.forgather.domain.guestbook.model.GuestBookCard;
 import com.forgather.domain.guestbook.model.GuestBookReportReason;
@@ -334,5 +335,110 @@ class GuestbookReportAcceptanceTest extends AcceptanceTest {
                 space.getCode(), card.getId())
             .then()
             .statusCode(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @DisplayName("신고 내역 상세 조회")
+    @Nested
+    class retrieveReportDetail {
+
+        @DisplayName("신고 내역이 있으면 200과 상세 정보를 반환한다")
+        @Test
+        void retrieveReportDetail() {
+            // given
+            String detail = "상세 신고 사유입니다";
+            ApiResponse<CreateGuestBookReportResponse> reportResult = RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(ContentType.JSON)
+                .body(new CreateGuestBookReportRequest(reason.getId(), detail))
+                .when()
+                .post("/spaces/{spaceCode}/guestbook/{cardId}/reports",
+                    space.getCode(), card.getId())
+                .then()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract()
+                .body()
+                .as(new TypeRef<>() {
+                });
+
+            // when
+            ApiResponse<ReportDetailResponse> result = RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(ContentType.JSON)
+                .when()
+                .get("/guestbook/me/reports/{reportId}", reportResult.data().id())
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body()
+                .as(new TypeRef<>() {
+                });
+
+            // then
+            assertAll(
+                () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(result.message()).isNull(),
+                () -> assertThat(result.data().id()).isEqualTo(reportResult.data().id()),
+                () -> assertThat(result.data().space().spaceCode()).isEqualTo(space.getCode()),
+                () -> assertThat(result.data().space().name()).isEqualTo(space.getName()),
+                () -> assertThat(result.data().reason().id()).isEqualTo(reason.getId()),
+                () -> assertThat(result.data().reason().label()).isEqualTo(reason.getLabel()),
+                () -> assertThat(result.data().detail()).isEqualTo(detail),
+                () -> assertThat(result.data().nicknameSnapshot()).isEqualTo("닉네임"),
+                () -> assertThat(result.data().messageSnapshot()).isEqualTo("방명록 메시지"),
+                () -> assertThat(result.data().createdAtSnapshot()).isNotNull(),
+                () -> assertThat(result.data().createdAt()).isNotNull()
+            );
+        }
+
+        @DisplayName("존재하지 않는 신고 내역은 조회할 수 없다")
+        @Test
+        void throwExceptionWhenReportNotFound() {
+            RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(ContentType.JSON)
+                .when()
+                .get("/guestbook/me/reports/{reportId}", 999L)
+                .then()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+        }
+
+        @DisplayName("다른 사용자의 신고 내역은 조회할 수 없다")
+        @Test
+        void throwExceptionWhenOtherHostReport() {
+            // given
+            ApiResponse<CreateGuestBookReportResponse> reportResult = RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .contentType(ContentType.JSON)
+                .body(new CreateGuestBookReportRequest(reason.getId(), null))
+                .when()
+                .post("/spaces/{spaceCode}/guestbook/{cardId}/reports",
+                    space.getCode(), card.getId())
+                .then()
+                .statusCode(HttpStatus.CREATED.value())
+                .extract()
+                .body()
+                .as(new TypeRef<>() {
+                });
+
+            // when & then
+            RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + anotherAccessToken)
+                .accept(ContentType.JSON)
+                .when()
+                .get("/guestbook/me/reports/{reportId}", reportResult.data().id())
+                .then()
+                .statusCode(HttpStatus.NOT_FOUND.value());
+        }
+
+        @DisplayName("비로그인 사용자는 상세 조회할 수 없다")
+        @Test
+        void throwExceptionWhenNotLoggedIn() {
+            RestAssuredMockMvc.given()
+                .accept(ContentType.JSON)
+                .when()
+                .get("/guestbook/me/reports/{reportId}", 1L)
+                .then()
+                .statusCode(HttpStatus.UNAUTHORIZED.value());
+        }
     }
 }

--- a/src/test/java/com/forgather/acceptance/GuestbookReportAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/GuestbookReportAcceptanceTest.java
@@ -427,7 +427,7 @@ class GuestbookReportAcceptanceTest extends AcceptanceTest {
                 .when()
                 .get("/guestbook/me/reports/{reportId}", reportResult.data().id())
                 .then()
-                .statusCode(HttpStatus.NOT_FOUND.value());
+                .statusCode(HttpStatus.FORBIDDEN.value());
         }
 
         @DisplayName("비로그인 사용자는 상세 조회할 수 없다")

--- a/src/test/java/com/forgather/domain/guestbook/service/GuestbookReportServiceTest.java
+++ b/src/test/java/com/forgather/domain/guestbook/service/GuestbookReportServiceTest.java
@@ -89,7 +89,7 @@ class GuestbookReportServiceTest {
         assertAll(
             () -> assertThat(response.id()).isNotNull(),
             () -> assertThat(response.guestBookCardId()).isEqualTo(card.getId()),
-            () -> assertThat(guestBookReportRepository.existsByGuestBookCardAndReporterUser(card, host)).isTrue(),
+            () -> assertThat(guestBookReportRepository.existsByGuestBookCardAndReporter(card, host)).isTrue(),
             () -> assertThat(card.getVisibilityStatus()).isEqualTo(VisibilityStatus.HIDDEN_BY_ADMIN)
         );
     }


### PR DESCRIPTION
## 연관된 이슈

- close #94

## 변경 사항

- 방명록 신고 내역 상세 조회 API 구현 (`GET /guestbook/me/reports/{reportId}`)
- `ReportDetailResponse` DTO 추가
- `GuestBookReportRepository`에 `findById`, `getByIdOrThrow` 추가
- `GuestBookReport`에 `equalsReporter` 메서드 추가
- `Host`에 `equals/hashCode` 추가
- `hostUser` → `spaceHost`, `reporterUser` → `reporter` 네이밍 변경

## 작업 내용

### API

### `GET /guestbook/me/reports/{reportId}`

로그인한 호스트 본인이 접수한 특정 방명록 신고 내역의 상세 정보를 조회합니다.

**[요청]**
| 위치 | 파라미터 | 타입 | 설명 |
|------|---------|------|------|
| Path | reportId | Long | 신고 내역 ID |

**[응답]**
| 상태 코드 | 설명 |
|-----------|------|
| 200 | 조회 성공 |
| 401 | 비로그인 사용자 |
| 403 | 다른 호스트의 신고 내역에 접근한 경우 |
| 404 | 존재하지 않는 신고 내역 ID |

**[응답 예시 - 200]**
```json
{
  "code": "SUCCESS",
  "message": null,
  "data": {
    "id": 1,
    "space": {
      "spaceCode": "abc123",
      "name": "나의 스페이스"
    },
    "reason": {
      "id": 2,
      "label": "욕설/비하"
    },
    "detail": "상세 신고 사유입니다",
    "nicknameSnapshot": "현주징징이",
    "messageSnapshot": "역겹다;;;;",
    "createdAtSnapshot": "2026-04-25T12:00:00",
    "createdAt": "2026-04-25T12:05:00"
  }
}
```

---

### 403 vs 404 응답 정책 논의 필요

타인의 신고 내역 ID로 접근 시 현재 403을 반환하도록 구현했습니다.

**[403 반환]**
- 접근 권한이 없음을 명확히 전달
- 해당 ID의 신고 내역이 존재한다는 사실이 노출됨

**[404 반환]**
- 해당 ID의 존재 여부 자체를 숨길 수 있어 보안에 유리
- 클라이언트 입장에서 "없는 건지, 권한이 없는 건지" 구분 불가

신고 내역 ID의 존재 여부가 노출되더라도 보안상 큰 위협이 되지 않는다고 판단해 403을 선택했습니다. 포스티는 어떻게 생각하시나요?

---

### `user` 네이밍 제거

이전 PR에서 엔티티 네이밍을 `user` 대신 `host`로 사용하기로 결정함에 따라, `GuestBookReport` 내 잔존하던 `user` 접미사를 제거했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 신고자가 자신의 게시판 신고 상세 정보를 조회할 수 있는 상세 조회 기능이 추가되었습니다.

* **개선 사항**
  * 신고자 본인 여부 검증을 강화해 타인의 신고 상세 열람을 차단하는 접근 제어가 개선되었습니다.

* **테스트**
  * 상세 조회 엔드포인트에 대한 통합/수용 테스트가 추가되어 정상/권한없음/미인증/미존재 시나리오를 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->