### PR TITLE
feature: 방명록 신고 사유 조회

### DIFF
--- a/src/main/java/com/forgather/domain/guestbook/controller/GuestbookController.java
+++ b/src/main/java/com/forgather/domain/guestbook/controller/GuestbookController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.forgather.domain.guestbook.dto.ReportDetailResponse;
 import com.forgather.domain.guestbook.dto.ReportHistoryResponse;
+import com.forgather.domain.guestbook.dto.ReportReasonsResponse;
 import com.forgather.domain.guestbook.service.GuestbookReportService;
 import com.forgather.global.auth.annotation.LoginHost;
 import com.forgather.global.auth.model.Host;
@@ -75,6 +76,14 @@ public class GuestbookController {
         @PathVariable Long reportId
     ) {
         var response = guestBookReportService.retrieveReportDetail(loginHost, reportId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @Operation(summary = "방명록 신고 사유 목록 조회",
+        description = "방명록 신고 시 선택 가능한 신고 사유 목록 조회")
+    @GetMapping("/reports/reasons")
+    public ResponseEntity<ApiResponse<ReportReasonsResponse>> retrieveReportReasons() {
+        var response = guestBookReportService.retrieveReportReasons();
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/forgather/domain/guestbook/dto/ReportReasonsResponse.java
+++ b/src/main/java/com/forgather/domain/guestbook/dto/ReportReasonsResponse.java
@@ -1,0 +1,19 @@
+package com.forgather.domain.guestbook.dto;
+
+import java.util.List;
+
+import com.forgather.domain.guestbook.model.GuestBookReportReason;
+
+public record ReportReasonsResponse(
+    List<ReasonInfo> reasons
+) {
+
+    public static ReportReasonsResponse from(List<GuestBookReportReason> reasons) {
+        return new ReportReasonsResponse(reasons.stream()
+            .map(reason -> new ReasonInfo(reason.getId(), reason.getLabel()))
+            .toList());
+    }
+
+    public record ReasonInfo(Long id, String label) {
+    }
+}

--- a/src/main/java/com/forgather/domain/guestbook/model/GuestBookReportReason.java
+++ b/src/main/java/com/forgather/domain/guestbook/model/GuestBookReportReason.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class GuestBookReportReason extends BaseTimeEntity {
+public class GuestBookReportReason extends BaseTimeEntity implements Comparable<GuestBookReportReason> {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -37,5 +37,10 @@ public class GuestBookReportReason extends BaseTimeEntity {
         this.label = label;
         this.displayOrder = displayOrder;
         this.isHidden = isHidden;
+    }
+
+    @Override
+    public int compareTo(GuestBookReportReason other) {
+        return Integer.compare(this.displayOrder, other.displayOrder);
     }
 }

--- a/src/main/java/com/forgather/domain/guestbook/repository/GuestBookReportReasonRepository.java
+++ b/src/main/java/com/forgather/domain/guestbook/repository/GuestBookReportReasonRepository.java
@@ -1,5 +1,6 @@
 package com.forgather.domain.guestbook.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import com.forgather.domain.guestbook.model.GuestBookReportReason;
@@ -9,6 +10,8 @@ import com.forgather.global.exception.NotFoundException;
 public interface GuestBookReportReasonRepository {
 
     Optional<GuestBookReportReason> findByIdAndIsHiddenFalse(Long id);
+
+    List<GuestBookReportReason> findAllByIsHiddenFalse();
 
     default GuestBookReportReason getByIdAndIsHiddenFalseOrThrow(Long id) {
         if (id == null) {

--- a/src/main/java/com/forgather/domain/guestbook/service/GuestbookReportService.java
+++ b/src/main/java/com/forgather/domain/guestbook/service/GuestbookReportService.java
@@ -1,5 +1,7 @@
 package com.forgather.domain.guestbook.service;
 
+import java.util.List;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -9,6 +11,7 @@ import com.forgather.domain.guestbook.dto.CreateGuestBookReportRequest;
 import com.forgather.domain.guestbook.dto.CreateGuestBookReportResponse;
 import com.forgather.domain.guestbook.dto.ReportDetailResponse;
 import com.forgather.domain.guestbook.dto.ReportHistoryResponse;
+import com.forgather.domain.guestbook.dto.ReportReasonsResponse;
 import com.forgather.domain.guestbook.model.GuestBookCard;
 import com.forgather.domain.guestbook.model.GuestBookReport;
 import com.forgather.domain.guestbook.model.GuestBookReportReason;
@@ -27,6 +30,7 @@ import com.forgather.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 @Service
 public class GuestbookReportService {
 
@@ -36,7 +40,6 @@ public class GuestbookReportService {
     private final GuestBookReportRepository guestBookReportRepository;
     private final GuestBookReportReasonRepository guestBookReportReasonRepository;
 
-    @Transactional(readOnly = true)
     public ReportHistoryResponse retrieveReportHistory(Host reporter, Pageable pageable) {
         Page<GuestBookReport> reports = guestBookReportRepository.findAllByReporter(
             reporter,
@@ -45,7 +48,6 @@ public class GuestbookReportService {
         return ReportHistoryResponse.from(reports);
     }
 
-    @Transactional(readOnly = true)
     public ReportDetailResponse retrieveReportDetail(Host reporter, Long reportId) {
         GuestBookReport report = guestBookReportRepository.getByIdOrThrow(reportId);
         if (!report.equalsReporter(reporter)) {
@@ -102,5 +104,10 @@ public class GuestbookReportService {
             "해당 스페이스에 대한 접근 권한이 없습니다. spaceCode: %s, hostId: %d"
                 .formatted(space.getCode(), host.getId())
         );
+    }
+
+    public ReportReasonsResponse retrieveReportReasons() {
+        List<GuestBookReportReason> reasons = guestBookReportReasonRepository.findAllByIsHiddenFalse();
+        return ReportReasonsResponse.from(reasons);
     }
 }

--- a/src/main/java/com/forgather/domain/guestbook/service/GuestbookReportService.java
+++ b/src/main/java/com/forgather/domain/guestbook/service/GuestbookReportService.java
@@ -1,5 +1,6 @@
 package com.forgather.domain.guestbook.service;
 
+import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -108,6 +109,7 @@ public class GuestbookReportService {
 
     public ReportReasonsResponse retrieveReportReasons() {
         List<GuestBookReportReason> reasons = guestBookReportReasonRepository.findAllByIsHiddenFalse();
+        reasons.sort(Comparator.comparingInt(GuestBookReportReason::getDisplayOrder));
         return ReportReasonsResponse.from(reasons);
     }
 }

--- a/src/main/java/com/forgather/domain/guestbook/service/GuestbookReportService.java
+++ b/src/main/java/com/forgather/domain/guestbook/service/GuestbookReportService.java
@@ -1,6 +1,5 @@
 package com.forgather.domain.guestbook.service;
 
-import java.util.Comparator;
 import java.util.List;
 
 import org.springframework.data.domain.Page;
@@ -109,7 +108,7 @@ public class GuestbookReportService {
 
     public ReportReasonsResponse retrieveReportReasons() {
         List<GuestBookReportReason> reasons = guestBookReportReasonRepository.findAllByIsHiddenFalse();
-        reasons.sort(Comparator.comparingInt(GuestBookReportReason::getDisplayOrder));
+        reasons.sort(GuestBookReportReason::compareTo);
         return ReportReasonsResponse.from(reasons);
     }
 }

--- a/src/test/java/com/forgather/acceptance/GuestbookReportAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/GuestbookReportAcceptanceTest.java
@@ -86,7 +86,7 @@ class GuestbookReportAcceptanceTest extends AcceptanceTest {
         spaceHostRepository.save(new SpaceHost(space, host));
 
         card = guestBookCardRepository.save(new GuestBookCard(space, "닉네임", "방명록 메시지"));
-        reason = reportReasonRepository.save(createReason());
+        reason = reportReasonRepository.save(createReason());  // 스팸, 1
 
         RestAssuredMockMvc.mockMvc(mockMvc);
     }
@@ -332,12 +332,13 @@ class GuestbookReportAcceptanceTest extends AcceptanceTest {
     @Nested
     class retrieveReportReasons {
 
-        @DisplayName("공개 신고 사유 목록을 반환한다")
+        @DisplayName("공개 신고 사유 목록을 노출 순서에 맞게 반환한다")
         @Test
         void retrieveThreeReportReasons() {
-            // given
-            reportReasonRepository.save(createReasonWithCode("HATE", "혐오 발언", 2));
-            reportReasonRepository.save(createReasonWithCode("ADULT", "성인 콘텐츠", 3));
+            // given (setUp의 spam이 order:1)
+            reportReasonRepository.save(createReasonWithCode("HATE", "혐오 발언", 4));
+            reportReasonRepository.save(createReasonWithCode("ADULT", "성인 콘텐츠", 2));
+            reportReasonRepository.save(createReasonWithCode("ETC", "기타", 3));
 
             // when
             ApiResponse<ReportReasonsResponse> result = RestAssuredMockMvc.given()
@@ -355,10 +356,9 @@ class GuestbookReportAcceptanceTest extends AcceptanceTest {
             assertAll(
                 () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
                 () -> assertThat(result.message()).isNull(),
-                () -> assertThat(result.data().reasons()).hasSize(3),
                 () -> assertThat(result.data().reasons())
                     .extracting(ReportReasonsResponse.ReasonInfo::label)
-                    .containsExactlyInAnyOrder("스팸", "혐오 발언", "성인 콘텐츠")
+                    .containsExactly("스팸", "성인 콘텐츠", "기타", "혐오 발언")
             );
         }
     }

--- a/src/test/java/com/forgather/acceptance/GuestbookReportAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/GuestbookReportAcceptanceTest.java
@@ -1,6 +1,7 @@
 package com.forgather.acceptance;
 
 import static com.forgather.fixture.GuestBookReportReasonFixture.createReason;
+import static com.forgather.fixture.GuestBookReportReasonFixture.createReasonWithCode;
 import static com.forgather.fixture.HostFixture.createHost;
 import static com.forgather.fixture.SpaceFixture.createSpace;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -17,6 +18,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.forgather.domain.guestbook.dto.CreateGuestBookReportRequest;
+import com.forgather.domain.guestbook.dto.ReportReasonsResponse;
 import com.forgather.domain.guestbook.dto.CreateGuestBookReportResponse;
 import com.forgather.domain.guestbook.dto.ReportDetailResponse;
 import com.forgather.domain.guestbook.dto.ReportHistoryResponse;
@@ -323,6 +325,41 @@ class GuestbookReportAcceptanceTest extends AcceptanceTest {
                 .then()
                 .statusCode(HttpStatus.UNAUTHORIZED.value())
                 .body("code", equalTo("UNAUTHORIZED"));
+        }
+    }
+
+    @DisplayName("신고 사유 조회")
+    @Nested
+    class retrieveReportReasons {
+
+        @DisplayName("공개 신고 사유 목록을 반환한다")
+        @Test
+        void retrieveThreeReportReasons() {
+            // given
+            reportReasonRepository.save(createReasonWithCode("HATE", "혐오 발언", 2));
+            reportReasonRepository.save(createReasonWithCode("ADULT", "성인 콘텐츠", 3));
+
+            // when
+            ApiResponse<ReportReasonsResponse> result = RestAssuredMockMvc.given()
+                .accept(ContentType.JSON)
+                .when()
+                .get("/guestbook/reports/reasons")
+                .then()
+                .statusCode(HttpStatus.OK.value())
+                .extract()
+                .body()
+                .as(new TypeRef<>() {
+                });
+
+            // then
+            assertAll(
+                () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+                () -> assertThat(result.message()).isNull(),
+                () -> assertThat(result.data().reasons()).hasSize(3),
+                () -> assertThat(result.data().reasons())
+                    .extracting(ReportReasonsResponse.ReasonInfo::label)
+                    .containsExactlyInAnyOrder("스팸", "혐오 발언", "성인 콘텐츠")
+            );
         }
     }
 

--- a/src/test/java/com/forgather/domain/guestbook/model/GuestBookReportReasonTest.java
+++ b/src/test/java/com/forgather/domain/guestbook/model/GuestBookReportReasonTest.java
@@ -1,0 +1,25 @@
+package com.forgather.domain.guestbook.model;
+
+import static com.forgather.fixture.GuestBookReportReasonFixture.createReasonWithCode;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class GuestBookReportReasonTest {
+
+    @DisplayName("신고 사유는 노출 순서로 비교된다")
+    @Test
+    void compareToComparesDisplayOrder() {
+        // given
+        GuestBookReportReason firstReason = createReasonWithCode("SPAM", "스팸", 1);
+        GuestBookReportReason secondReason = createReasonWithCode("ADULT", "성인 콘텐츠", 2);
+
+        // when & then
+        assertAll(
+            () -> assertThat(firstReason.compareTo(secondReason)).isNegative(),
+            () -> assertThat(secondReason.compareTo(firstReason)).isPositive()
+        );
+    }
+}

--- a/src/test/java/com/forgather/domain/guestbook/service/GuestbookReportServiceTest.java
+++ b/src/test/java/com/forgather/domain/guestbook/service/GuestbookReportServiceTest.java
@@ -2,6 +2,7 @@ package com.forgather.domain.guestbook.service;
 
 import static com.forgather.fixture.GuestBookReportReasonFixture.createHiddenReason;
 import static com.forgather.fixture.GuestBookReportReasonFixture.createReason;
+import static com.forgather.fixture.GuestBookReportReasonFixture.createReasonWithCode;
 import static com.forgather.fixture.HostFixture.createHost;
 import static com.forgather.fixture.SpaceFixture.createSpace;
 import static com.forgather.fixture.SpaceFixture.createSpaceWithCode;
@@ -21,6 +22,7 @@ import org.springframework.data.domain.Sort;
 import com.forgather.domain.guestbook.dto.CreateGuestBookReportRequest;
 import com.forgather.domain.guestbook.dto.CreateGuestBookReportResponse;
 import com.forgather.domain.guestbook.dto.ReportHistoryResponse;
+import com.forgather.domain.guestbook.dto.ReportReasonsResponse;
 import com.forgather.domain.guestbook.model.GuestBookCard;
 import com.forgather.domain.guestbook.model.GuestBookReportReason;
 import com.forgather.domain.guestbook.model.VisibilityStatus;
@@ -230,5 +232,23 @@ class GuestbookReportServiceTest {
 
         // then
         assertThat(result.reportHistory()).isEmpty();
+    }
+
+    @DisplayName("공개 신고 사유 목록을 노출 순서에 맞게 반환한다")
+    @Test
+    void retrieveReportReasonsSortsByDisplayOrder() {
+        // given
+        reportReasonRepository.save(createReasonWithCode("HATE", "혐오 발언", 4));
+        reportReasonRepository.save(createReasonWithCode("ADULT", "성인 콘텐츠", 2));
+        reportReasonRepository.save(createReasonWithCode("ETC", "기타", 3));
+        reportReasonRepository.save(createHiddenReason());
+
+        // when
+        ReportReasonsResponse result = guestBookReportService.retrieveReportReasons();
+
+        // then
+        assertThat(result.reasons())
+            .extracting(ReportReasonsResponse.ReasonInfo::label)
+            .containsExactly("스팸", "성인 콘텐츠", "기타", "혐오 발언");
     }
 }

--- a/src/test/java/com/forgather/fixture/GuestBookReportReasonFixture.java
+++ b/src/test/java/com/forgather/fixture/GuestBookReportReasonFixture.java
@@ -11,4 +11,8 @@ public class GuestBookReportReasonFixture {
     public static GuestBookReportReason createHiddenReason() {
         return new GuestBookReportReason("OTHER", "기타", 1, true);
     }
+
+    public static GuestBookReportReason createReasonWithCode(String code, String label, int displayOrder) {
+        return new GuestBookReportReason(code, label, displayOrder, false);
+    }
 }


### PR DESCRIPTION
## 연관된 이슈

- close #97

## 변경 사항

- 방명록 신고 사유 목록 조회 API 구현 (`GET /guestbook/reports/reasons`)
- `ReportReasonsResponse` DTO 추가
- `GuestBookReportReasonRepository`에 `findAllByIsHiddenFalse()` 추가
- `GuestbookReportService`에 `@Transactional(readOnly = true)` 클래스 레벨로 이동

## 작업 내용

### API

### `GET /guestbook/reports/reasons`

방명록 신고 시 선택 가능한 신고 사유 목록을 조회합니다. 신고 사유는 공개 정보이므로 인증 없이 접근 가능합니다.

**[요청]**

없음

**[응답]**
| 상태 코드 | 설명 |
|-----------|------|
| 200 | 조회 성공 |

**[응답 예시 - 200]**
```json
{
  "code": "SUCCESS",
  "message": null,
  "data": {
    "reasons": [
      { "id": 1, "label": "스팸" },
      { "id": 2, "label": "혐오 발언" },
      { "id": 3, "label": "성인 콘텐츠" }
    ]
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 방명록 신고 사유 목록 조회 API가 추가되어, 숨김 처리되지 않은 사유를 우선순위(표시 순서)대로 확인할 수 있습니다.

* **Tests**
  * 관련 인수·단위 테스트가 추가되어 반환 항목과 정렬 순서를 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->