### PR TITLE
refactor: 스페이스에 종속된 사진 업로드 기능 개선

### DIFF
--- a/src/main/java/com/forgather/domain/exhibition/dto/CreateExhibitionPhotoRequest.java
+++ b/src/main/java/com/forgather/domain/exhibition/dto/CreateExhibitionPhotoRequest.java
@@ -1,0 +1,26 @@
+package com.forgather.domain.exhibition.dto;
+
+import com.forgather.domain.exhibition.model.Exhibition;
+import com.forgather.domain.exhibition.model.ExhibitionPhoto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record CreateExhibitionPhotoRequest(
+
+    @Schema(description = "업로드 파일명 (UUID.확장자)", example = "UUID.webp")
+    @NotBlank
+    String uploadFileName,
+
+    @Schema(description = "전시 이미지 파일 크기 (bytes)", example = "102400")
+    @Positive
+    @NotNull
+    Long capacity
+) {
+
+    public ExhibitionPhoto toEntity(String path, Exhibition exhibition) {
+        return new ExhibitionPhoto(path, capacity, exhibition);
+    }
+}

--- a/src/main/java/com/forgather/domain/exhibition/dto/CreateExhibitionRequest.java
+++ b/src/main/java/com/forgather/domain/exhibition/dto/CreateExhibitionRequest.java
@@ -3,24 +3,21 @@ package com.forgather.domain.exhibition.dto;
 import java.time.LocalDate;
 import java.util.List;
 
+import com.forgather.domain.exhibition.model.Exhibition;
+
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 
 public record CreateExhibitionRequest(
 
-    @Schema(description = "전시 이미지 경로 (S3 key)", example = "exhibitions/abc.webp")
-    @NotBlank
-    String imagePath,
-
-    @Schema(description = "전시 이미지 파일 크기 (bytes)", example = "102400")
-    @Positive
+    @Schema(description = "전시 대표 이미지")
+    @Valid
     @NotNull
-    Long imageCapacity,
+    CreateExhibitionPhotoRequest photo,
 
     @Schema(description = "전시 제목 (최대 100자)", example = "봄 전시")
     @NotBlank

--- a/src/main/java/com/forgather/domain/exhibition/dto/CreateExhibitionRequest.java
+++ b/src/main/java/com/forgather/domain/exhibition/dto/CreateExhibitionRequest.java
@@ -3,8 +3,6 @@ package com.forgather.domain.exhibition.dto;
 import java.time.LocalDate;
 import java.util.List;
 
-import com.forgather.domain.exhibition.model.Exhibition;
-
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
@@ -14,9 +12,8 @@ import jakarta.validation.constraints.Size;
 
 public record CreateExhibitionRequest(
 
-    @Schema(description = "전시 대표 이미지")
+    @Schema(description = "전시 대표 이미지 (선택, null 가능)")
     @Valid
-    @NotNull
     CreateExhibitionPhotoRequest photo,
 
     @Schema(description = "전시 제목 (최대 100자)", example = "봄 전시")

--- a/src/main/java/com/forgather/domain/exhibition/dto/ExhibitionResponse.java
+++ b/src/main/java/com/forgather/domain/exhibition/dto/ExhibitionResponse.java
@@ -27,8 +27,8 @@ public record ExhibitionResponse(
     @Schema(description = "운영 공지 (미설정 시 null)", example = "첫번째 주 일요일은 휴관합니다.")
     String operationNotice,
 
-    @Schema(description = "대표 이미지 경로", example = "exhibitions/abc.webp")
-    String representativeImagePath,
+    @Schema(description = "대표 이미지 경로 (미설정 시 null)", example = "exhibitions/abc.webp")
+    String photoPath,
 
     @Schema(description = "시작일", example = "2026-06-01")
     LocalDate startDate,
@@ -77,7 +77,7 @@ public record ExhibitionResponse(
             exhibition.getTitle(),
             exhibition.getDescription(),
             exhibition.getOperationNotice(),
-            photo.getPath(),
+            photo == null ? null : photo.getPath(),
             exhibition.getStartDate(),
             exhibition.getEndDate(),
             exhibition.calculateProgressStatus(LocalDate.now(ZoneId.of("Asia/Seoul"))).name(),

--- a/src/main/java/com/forgather/domain/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/forgather/domain/exhibition/service/ExhibitionService.java
@@ -18,6 +18,8 @@ import com.forgather.domain.exhibition.repository.ExhibitionHostRepository;
 import com.forgather.domain.exhibition.repository.ExhibitionPhotoRepository;
 import com.forgather.domain.exhibition.repository.ExhibitionRepository;
 import com.forgather.domain.exhibition.repository.ExhibitionTimeRepository;
+import com.forgather.domain.upload.domain.ContentsStorage;
+import com.forgather.domain.upload.domain.FilePathGenerator;
 import com.forgather.global.auth.model.Host;
 
 import lombok.RequiredArgsConstructor;
@@ -30,14 +32,15 @@ public class ExhibitionService {
     private final ExhibitionHostRepository exhibitionHostRepository;
     private final ExhibitionPhotoRepository exhibitionPhotoRepository;
     private final ExhibitionTimeRepository exhibitionTimeRepository;
+    private final ContentsStorage contentsStorage;
 
     @Transactional
     public ExhibitionResponse create(Host host, CreateExhibitionRequest request) {
         Exhibition exhibition = exhibitionRepository.save(buildExhibition(request));
 
-        // TODO: photo path 검증(정말 s3에 존재하는 객체인가?
+        String photoPath = buildPhotoPath(host, request.photo().uploadFileName());
         ExhibitionPhoto photo = exhibitionPhotoRepository.save(
-            new ExhibitionPhoto(request.imagePath(), request.imageCapacity(), exhibition)
+            request.photo().toEntity(photoPath, exhibition)
         );
 
         ExhibitionTimes exhibitionTimes = buildExhibitionTimes(request, exhibition);
@@ -46,6 +49,12 @@ public class ExhibitionService {
         exhibitionHostRepository.save(new ExhibitionHost(exhibition, host, true));
 
         return ExhibitionResponse.of(exhibition, photo, exhibitionTimes, host);
+    }
+
+    private String buildPhotoPath(Host host, String uploadFileName) {
+        return FilePathGenerator.generateExhibitionContentsFilePath(
+            contentsStorage.getRootDirectory(), host.getId(), uploadFileName
+        );
     }
 
     private Exhibition buildExhibition(CreateExhibitionRequest request) {

--- a/src/main/java/com/forgather/domain/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/forgather/domain/exhibition/service/ExhibitionService.java
@@ -38,7 +38,7 @@ public class ExhibitionService {
     public ExhibitionResponse create(Host host, CreateExhibitionRequest request) {
         Exhibition exhibition = exhibitionRepository.save(buildExhibition(request));
 
-        String photoPath = buildPhotoPath(host, request.photo().uploadFileName());
+        String photoPath = buildPhotoPath(request.photo().uploadFileName());
         ExhibitionPhoto photo = exhibitionPhotoRepository.save(
             request.photo().toEntity(photoPath, exhibition)
         );
@@ -51,9 +51,9 @@ public class ExhibitionService {
         return ExhibitionResponse.of(exhibition, photo, exhibitionTimes, host);
     }
 
-    private String buildPhotoPath(Host host, String uploadFileName) {
+    private String buildPhotoPath(String uploadFileName) {
         return FilePathGenerator.generateExhibitionContentsFilePath(
-            contentsStorage.getRootDirectory(), host.getId(), uploadFileName
+            contentsStorage.getRootDirectory(), uploadFileName
         );
     }
 

--- a/src/main/java/com/forgather/domain/exhibition/service/ExhibitionService.java
+++ b/src/main/java/com/forgather/domain/exhibition/service/ExhibitionService.java
@@ -38,10 +38,7 @@ public class ExhibitionService {
     public ExhibitionResponse create(Host host, CreateExhibitionRequest request) {
         Exhibition exhibition = exhibitionRepository.save(buildExhibition(request));
 
-        String photoPath = buildPhotoPath(request.photo().uploadFileName());
-        ExhibitionPhoto photo = exhibitionPhotoRepository.save(
-            request.photo().toEntity(photoPath, exhibition)
-        );
+        ExhibitionPhoto photo = savePhotoIfPresent(request, exhibition);
 
         ExhibitionTimes exhibitionTimes = buildExhibitionTimes(request, exhibition);
         exhibitionTimeRepository.saveAll(exhibitionTimes.getValues());
@@ -49,6 +46,14 @@ public class ExhibitionService {
         exhibitionHostRepository.save(new ExhibitionHost(exhibition, host, true));
 
         return ExhibitionResponse.of(exhibition, photo, exhibitionTimes, host);
+    }
+
+    private ExhibitionPhoto savePhotoIfPresent(CreateExhibitionRequest request, Exhibition exhibition) {
+        if (request.photo() == null) {
+            return null;
+        }
+        String photoPath = buildPhotoPath(request.photo().uploadFileName());
+        return exhibitionPhotoRepository.save(request.photo().toEntity(photoPath, exhibition));
     }
 
     private String buildPhotoPath(String uploadFileName) {

--- a/src/main/java/com/forgather/domain/upload/AwsS3Cloud.java
+++ b/src/main/java/com/forgather/domain/upload/AwsS3Cloud.java
@@ -146,7 +146,27 @@ public class AwsS3Cloud implements ContentsStorage {
             .key(path)
             .tagging(s3Properties.getTagging())
             .build();
+        return presign(objectRequest);
+    }
 
+    /**
+     * Content-Type과 Content-Length를 서명에 포함해 고정한다.
+     * 클라이언트는 PUT 시 동일한 Content-Type 헤더와 정확히 contentLength 바이트를 보내야만 업로드가 통과하므로,
+     * 임의 MIME 타입 업로드와 대용량 업로드를 모두 차단한다.
+     */
+    @Override
+    public String issueSignedUrl(String path, String contentType, long contentLength) {
+        PutObjectRequest objectRequest = PutObjectRequest.builder()
+            .bucket(s3Properties.getBucketName())
+            .key(path)
+            .tagging(s3Properties.getTagging())
+            .contentType(contentType)
+            .contentLength(contentLength)
+            .build();
+        return presign(objectRequest);
+    }
+
+    private String presign(PutObjectRequest objectRequest) {
         PutObjectPresignRequest preSignRequest = PutObjectPresignRequest.builder()
             .signatureDuration(Duration.ofMinutes(10L)) // 10MBps 에서 5MB 4초 -> 최대 100장 제한, 넉넉히 600초
             .putObjectRequest(objectRequest)

--- a/src/main/java/com/forgather/domain/upload/AwsS3Cloud.java
+++ b/src/main/java/com/forgather/domain/upload/AwsS3Cloud.java
@@ -140,6 +140,8 @@ public class AwsS3Cloud implements ContentsStorage {
     }
 
     @Override
+    @Deprecated(forRemoval = true)
+    @SuppressWarnings("removal")
     public String issueSignedUrl(String path) {
         PutObjectRequest objectRequest = PutObjectRequest.builder()
             .bucket(s3Properties.getBucketName())
@@ -149,11 +151,6 @@ public class AwsS3Cloud implements ContentsStorage {
         return presign(objectRequest);
     }
 
-    /**
-     * Content-Type과 Content-Length를 서명에 포함해 고정한다.
-     * 클라이언트는 PUT 시 동일한 Content-Type 헤더와 정확히 contentLength 바이트를 보내야만 업로드가 통과하므로,
-     * 임의 MIME 타입 업로드와 대용량 업로드를 모두 차단한다.
-     */
     @Override
     public String issueSignedUrl(String path, String contentType, long contentLength) {
         PutObjectRequest objectRequest = PutObjectRequest.builder()

--- a/src/main/java/com/forgather/domain/upload/controller/UploadController.java
+++ b/src/main/java/com/forgather/domain/upload/controller/UploadController.java
@@ -27,6 +27,24 @@ import lombok.extern.slf4j.Slf4j;
 @Tag(name = "Upload: 파일 업로드", description = "파일 업로드 관련 API")
 public class UploadController {
 
+    private static final String PRESIGN_USAGE_NOTE = """
+        
+        
+        ── 발급된 presigned URL 사용 시 주의사항 ──
+        업로드 파일은 이미지만 허용됩니다. (확장자: jpg, jpeg, png, webp)
+        
+        1. Content-Type 고정
+           각 URL에는 파일 확장자로부터 결정된 Content-Type이 서명에 포함됩니다.
+           PUT 요청 시 동일한 Content-Type 헤더를 보내야 합니다.
+           (jpg·jpeg → image/jpeg, png → image/png, webp → image/webp)
+        
+        2. Content-Length 고정
+           각 URL에는 요청 시 보낸 size(바이트)가 서명에 포함됩니다.
+           PUT 요청 본문은 정확히 그 바이트 수여야 합니다. (파일당 최대 20MB)
+        
+        3. Content-Type 또는 크기가 일치하지 않으면 S3가 403(SignatureDoesNotMatch)을 반환합니다.
+        """;
+
     private final UploadService uploadService;
 
     /**
@@ -51,7 +69,7 @@ public class UploadController {
 
     @PostMapping(path = "/spaces/{spaceCode}/guestbooks/upload/signed-urls")
     @Operation(summary = "스페이스 방명록 사진 업로드 URL 발급",
-        description = "스페이스 방명록 사진 업로드용 presigned URL을 발급받습니다.")
+        description = "스페이스 방명록 사진 업로드용 presigned URL을 발급받습니다." + PRESIGN_USAGE_NOTE)
     public ResponseEntity<ApiResponse<IssueSignedUrlResponse>> issueGuestbookPreSignedUrls(
         @PathVariable(name = "spaceCode") String spaceCode,
         @Valid @RequestBody IssuePreSignedUrlRequest request
@@ -63,7 +81,7 @@ public class UploadController {
     @SecurityRequirement(name = "bearerAuth")
     @PostMapping(path = "/spaces/{spaceCode}/products/upload/signed-urls")
     @Operation(summary = "스페이스 작품 사진 업로드 URL 발급",
-        description = "로그인한 호스트가 자신의 스페이스 작품 사진 업로드용 presigned URL을 발급받습니다.")
+        description = "로그인한 호스트가 자신의 스페이스 작품 사진 업로드용 presigned URL을 발급받습니다." + PRESIGN_USAGE_NOTE)
     public ResponseEntity<ApiResponse<IssueSignedUrlResponse>> issueProductSignedUrls(
         @LoginHost(required = true) Host host,
         @PathVariable(name = "spaceCode") String spaceCode,
@@ -76,7 +94,7 @@ public class UploadController {
     @SecurityRequirement(name = "bearerAuth")
     @PostMapping(path = "/exhibitions/upload/signed-urls")
     @Operation(summary = "전시 사진 업로드 URL 발급",
-        description = "로그인한 호스트가 전시 사진 업로드용 presigned URL을 발급받습니다.")
+        description = "로그인한 호스트가 전시 사진 업로드용 presigned URL을 발급받습니다." + PRESIGN_USAGE_NOTE)
     public ResponseEntity<ApiResponse<IssueSignedUrlResponse>> issueExhibitionSignedUrls(
         @LoginHost(required = true) Host host,
         @Valid @RequestBody IssuePreSignedUrlRequest request

--- a/src/main/java/com/forgather/domain/upload/controller/UploadController.java
+++ b/src/main/java/com/forgather/domain/upload/controller/UploadController.java
@@ -46,7 +46,17 @@ public class UploadController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
-    // TODO: 기존 Space 관련(Product, Guestbook) 사진 업로드 presigned-url 발급 API URL 변경
+    @PostMapping(path = "/spaces/{spaceCode}/guestbooks/upload/signed-urls")
+    @Operation(summary = "스페이스 방명록 사진 업로드 URL 발급",
+        description = "스페이스 방명록 사진 업로드용 presigned URL을 발급받습니다.")
+    public ResponseEntity<ApiResponse<IssueSignedUrlResponse>> issueGuestbookPreSignedUrls(
+        @PathVariable(name = "spaceCode") String spaceCode,
+        @RequestBody IssueSignedUrlRequest request
+    ) {
+        var response = uploadService.issueGuestbookSignedUrls(spaceCode, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
     @SecurityRequirement(name = "bearerAuth")
     @PostMapping(path = "/spaces/{spaceCode}/products/upload/signed-urls")
     @Operation(summary = "스페이스 작품 사진 업로드 URL 발급",

--- a/src/main/java/com/forgather/domain/upload/controller/UploadController.java
+++ b/src/main/java/com/forgather/domain/upload/controller/UploadController.java
@@ -31,12 +31,12 @@ public class UploadController {
         
         
         ── 발급된 presigned URL 사용 시 주의사항 ──
-        업로드 파일은 이미지만 허용됩니다. (확장자: jpg, jpeg, png, webp)
+        업로드 파일은 이미지만 허용됩니다. (확장자: webp)
         
         1. Content-Type 고정
            각 URL에는 파일 확장자로부터 결정된 Content-Type이 서명에 포함됩니다.
            PUT 요청 시 동일한 Content-Type 헤더를 보내야 합니다.
-           (jpg·jpeg → image/jpeg, png → image/png, webp → image/webp)
+           (webp → image/webp)
         
         2. Content-Length 고정
            각 URL에는 요청 시 보낸 size(바이트)가 서명에 포함됩니다.

--- a/src/main/java/com/forgather/domain/upload/controller/UploadController.java
+++ b/src/main/java/com/forgather/domain/upload/controller/UploadController.java
@@ -96,7 +96,7 @@ public class UploadController {
         @LoginHost(required = true) Host host,
         @Valid @RequestBody IssuePreSignedUrlRequest request
     ) {
-        var response = uploadService.issueExhibitionSignedUrls(host, request);
+        var response = uploadService.issueExhibitionSignedUrls(request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 }

--- a/src/main/java/com/forgather/domain/upload/controller/UploadController.java
+++ b/src/main/java/com/forgather/domain/upload/controller/UploadController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.forgather.domain.upload.dto.IssuePreSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlResponse;
 import com.forgather.domain.upload.service.UploadService;
@@ -16,6 +17,7 @@ import com.forgather.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -30,6 +32,7 @@ public class UploadController {
     /**
      * TODO
      * 아무런 검증이 없어도 되는가?
+     * 추후 제거
      */
     @PostMapping(path = "/spaces/{spaceCode}/upload/signed-urls")
     @Operation(summary = "업로드 URL 발급", description = """
@@ -51,7 +54,7 @@ public class UploadController {
         description = "스페이스 방명록 사진 업로드용 presigned URL을 발급받습니다.")
     public ResponseEntity<ApiResponse<IssueSignedUrlResponse>> issueGuestbookPreSignedUrls(
         @PathVariable(name = "spaceCode") String spaceCode,
-        @RequestBody IssueSignedUrlRequest request
+        @Valid @RequestBody IssuePreSignedUrlRequest request
     ) {
         var response = uploadService.issueGuestbookSignedUrls(spaceCode, request);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -64,7 +67,7 @@ public class UploadController {
     public ResponseEntity<ApiResponse<IssueSignedUrlResponse>> issueProductSignedUrls(
         @LoginHost(required = true) Host host,
         @PathVariable(name = "spaceCode") String spaceCode,
-        @RequestBody IssueSignedUrlRequest request
+        @Valid @RequestBody IssuePreSignedUrlRequest request
     ) {
         var response = uploadService.issueProductSignedUrls(spaceCode, host, request);
         return ResponseEntity.ok(ApiResponse.success(response));
@@ -76,7 +79,7 @@ public class UploadController {
         description = "로그인한 호스트가 전시 사진 업로드용 presigned URL을 발급받습니다.")
     public ResponseEntity<ApiResponse<IssueSignedUrlResponse>> issueExhibitionSignedUrls(
         @LoginHost(required = true) Host host,
-        @RequestBody IssueSignedUrlRequest request
+        @Valid @RequestBody IssuePreSignedUrlRequest request
     ) {
         var response = uploadService.issueExhibitionSignedUrls(host, request);
         return ResponseEntity.ok(ApiResponse.success(response));

--- a/src/main/java/com/forgather/domain/upload/controller/UploadController.java
+++ b/src/main/java/com/forgather/domain/upload/controller/UploadController.java
@@ -47,11 +47,8 @@ public class UploadController {
 
     private final UploadService uploadService;
 
-    /**
-     * TODO
-     * 아무런 검증이 없어도 되는가?
-     * 추후 제거
-     */
+    @Deprecated(forRemoval = true)
+    @SuppressWarnings("removal")
     @PostMapping(path = "/spaces/{spaceCode}/upload/signed-urls")
     @Operation(summary = "업로드 URL 발급", description = """
             업로드 파일 별 서명된 URL을 발급합니다.

--- a/src/main/java/com/forgather/domain/upload/controller/UploadController.java
+++ b/src/main/java/com/forgather/domain/upload/controller/UploadController.java
@@ -4,15 +4,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlResponse;
 import com.forgather.domain.upload.service.UploadService;
+import com.forgather.global.auth.annotation.LoginHost;
+import com.forgather.global.auth.model.Host;
 import com.forgather.global.response.ApiResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,7 +22,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/spaces/{spaceCode}/upload")
 @Tag(name = "Upload: 파일 업로드", description = "파일 업로드 관련 API")
 public class UploadController {
 
@@ -30,7 +31,7 @@ public class UploadController {
      * TODO
      * 아무런 검증이 없어도 되는가?
      */
-    @PostMapping(path = "/signed-urls")
+    @PostMapping(path = "/spaces/{spaceCode}/upload/signed-urls")
     @Operation(summary = "업로드 URL 발급", description = """
             업로드 파일 별 서명된 URL을 발급합니다.
             category는 업로드할 사진의 종류를 뜻합니다.
@@ -44,4 +45,18 @@ public class UploadController {
         var response = uploadService.issueSignedUrls(spaceCode, request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
+
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping(path = "/exhibitions/upload/signed-urls")
+    @Operation(summary = "전시 사진 업로드 URL 발급",
+        description = "로그인한 호스트가 전시 사진 업로드용 presigned URL을 발급받습니다.")
+    public ResponseEntity<ApiResponse<IssueSignedUrlResponse>> issueExhibitionSignedUrls(
+        @LoginHost(required = true) Host host,
+        @RequestBody IssueSignedUrlRequest request
+    ) {
+        var response = uploadService.issueExhibitionSignedUrls(host, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    // TODO: 기존 Space 관련(Product, Guestbook) 사진 업로드 presigned-url 발급 API URL 변경
 }

--- a/src/main/java/com/forgather/domain/upload/controller/UploadController.java
+++ b/src/main/java/com/forgather/domain/upload/controller/UploadController.java
@@ -46,6 +46,20 @@ public class UploadController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    // TODO: 기존 Space 관련(Product, Guestbook) 사진 업로드 presigned-url 발급 API URL 변경
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping(path = "/spaces/{spaceCode}/products/upload/signed-urls")
+    @Operation(summary = "스페이스 작품 사진 업로드 URL 발급",
+        description = "로그인한 호스트가 자신의 스페이스 작품 사진 업로드용 presigned URL을 발급받습니다.")
+    public ResponseEntity<ApiResponse<IssueSignedUrlResponse>> issueProductSignedUrls(
+        @LoginHost(required = true) Host host,
+        @PathVariable(name = "spaceCode") String spaceCode,
+        @RequestBody IssueSignedUrlRequest request
+    ) {
+        var response = uploadService.issueProductSignedUrls(spaceCode, host, request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
     @SecurityRequirement(name = "bearerAuth")
     @PostMapping(path = "/exhibitions/upload/signed-urls")
     @Operation(summary = "전시 사진 업로드 URL 발급",
@@ -57,6 +71,4 @@ public class UploadController {
         var response = uploadService.issueExhibitionSignedUrls(host, request);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
-
-    // TODO: 기존 Space 관련(Product, Guestbook) 사진 업로드 presigned-url 발급 API URL 변경
 }

--- a/src/main/java/com/forgather/domain/upload/domain/ContentsStorage.java
+++ b/src/main/java/com/forgather/domain/upload/domain/ContentsStorage.java
@@ -13,7 +13,10 @@ public interface ContentsStorage {
 
     void deleteContents(List<String> contentPaths);
 
+    // 추후 제거
     String issueSignedUrl(String path);
+
+    String issueSignedUrl(String path, String contentType, long contentLength);
 
     String getRootDirectory();
 

--- a/src/main/java/com/forgather/domain/upload/domain/ContentsStorage.java
+++ b/src/main/java/com/forgather/domain/upload/domain/ContentsStorage.java
@@ -13,9 +13,21 @@ public interface ContentsStorage {
 
     void deleteContents(List<String> contentPaths);
 
-    // 추후 제거
+    // TODO: 추후 제거
+    @Deprecated(forRemoval = true)
+    @SuppressWarnings("removal")
     String issueSignedUrl(String path);
 
+    /**
+     * Content-Type과 Content-Length를 서명에 포함한 presigned URL을 발급합니다.
+     * 클라이언트는 PUT 요청 시 동일한 Content-Type과 정확히 contentLength 바이트를 전송해야 합니다.
+     * <p>
+     *
+     * @param path          S3 객체 경로
+     * @param contentType   MIME 타입 (예: image/jpeg)
+     * @param contentLength 파일 크기 (바이트)
+     * @return presigned PUT URL
+     */
     String issueSignedUrl(String path, String contentType, long contentLength);
 
     String getRootDirectory();

--- a/src/main/java/com/forgather/domain/upload/domain/FilePathGenerator.java
+++ b/src/main/java/com/forgather/domain/upload/domain/FilePathGenerator.java
@@ -42,12 +42,10 @@ public class FilePathGenerator {
 
     public static String generateExhibitionContentsFilePath(
         String rootDirectory,
-        Long hostId,
         String fileName
     ) {
-        return "%s/exhibitions/host-%d/%s".formatted(
+        return "%s/exhibitions/%s".formatted(
             rootDirectory,
-            hostId,
             fileName
         );
     }

--- a/src/main/java/com/forgather/domain/upload/domain/FilePathGenerator.java
+++ b/src/main/java/com/forgather/domain/upload/domain/FilePathGenerator.java
@@ -40,7 +40,15 @@ public class FilePathGenerator {
         return "%s.%s".formatted(uploadFileName, extension);
     }
 
-    public static String generateExhibitionContentsFilePath(String rootDirectory, long hostId, String fileName) {
-        return "%s/exhibitions/host-%d/%s".formatted(rootDirectory, hostId, fileName);
+    public static String generateExhibitionContentsFilePath(
+        String rootDirectory,
+        Long hostId,
+        String fileName
+    ) {
+        return "%s/exhibitions/host-%d/%s".formatted(
+            rootDirectory,
+            hostId,
+            fileName
+        );
     }
 }

--- a/src/main/java/com/forgather/domain/upload/domain/FilePathGenerator.java
+++ b/src/main/java/com/forgather/domain/upload/domain/FilePathGenerator.java
@@ -39,4 +39,8 @@ public class FilePathGenerator {
         String extension = StringUtils.getFilenameExtension(file.getOriginalFilename());
         return "%s.%s".formatted(uploadFileName, extension);
     }
+
+    public static String generateExhibitionContentsFilePath(String rootDirectory, long hostId, String fileName) {
+        return "%s/exhibitions/host-%d/%s".formatted(rootDirectory, hostId, fileName);
+    }
 }

--- a/src/main/java/com/forgather/domain/upload/domain/ImageContentType.java
+++ b/src/main/java/com/forgather/domain/upload/domain/ImageContentType.java
@@ -1,0 +1,41 @@
+package com.forgather.domain.upload.domain;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import org.springframework.util.StringUtils;
+
+import com.forgather.global.exception.BaseException;
+
+public enum ImageContentType {
+
+    JPEG("image/jpeg", "jpg", "jpeg"),
+    PNG("image/png", "png"),
+    WEBP("image/webp", "webp"),
+    ;
+
+    private final String mimeType;
+    private final Set<String> extensions;
+
+    ImageContentType(String mimeType, String... extensions) {
+        this.mimeType = mimeType;
+        this.extensions = Set.of(extensions);
+    }
+
+    public static String resolveByFileName(String fileName) {
+        String extension = extractExtension(fileName);
+        return Arrays.stream(values())
+            .filter(type -> type.extensions.contains(extension))
+            .findFirst()
+            .map(type -> type.mimeType)
+            .orElseThrow(() -> new BaseException("지원하지 않는 이미지 확장자입니다: " + fileName));
+    }
+
+    private static String extractExtension(String fileName) {
+        String extension = StringUtils.getFilenameExtension(fileName);
+        if (extension == null || extension.isBlank()) {
+            throw new BaseException("파일 확장자를 확인할 수 없습니다: " + fileName);
+        }
+        return extension.toLowerCase();
+    }
+}

--- a/src/main/java/com/forgather/domain/upload/domain/ImageContentType.java
+++ b/src/main/java/com/forgather/domain/upload/domain/ImageContentType.java
@@ -1,6 +1,7 @@
 package com.forgather.domain.upload.domain;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.util.StringUtils;
@@ -9,8 +10,6 @@ import com.forgather.global.exception.BaseException;
 
 public enum ImageContentType {
 
-    JPEG("image/jpeg", "jpg", "jpeg"),
-    PNG("image/png", "png"),
     WEBP("image/webp", "webp"),
     ;
 
@@ -22,20 +21,28 @@ public enum ImageContentType {
         this.extensions = Set.of(extensions);
     }
 
+    /**
+     * 파일명의 확장자가 지원하는 이미지 형식인지 여부를 반환한다.
+     * 확장자가 없거나 지원 목록에 없으면 false이며, 확장자 대소문자는 구분하지 않는다.
+     */
+    public static boolean isSupportedFileName(String fileName) {
+        return findByFileName(fileName).isPresent();
+    }
+
     public static String resolveByFileName(String fileName) {
-        String extension = extractExtension(fileName);
-        return Arrays.stream(values())
-            .filter(type -> type.extensions.contains(extension))
-            .findFirst()
+        return findByFileName(fileName)
             .map(type -> type.mimeType)
             .orElseThrow(() -> new BaseException("지원하지 않는 이미지 확장자입니다: " + fileName));
     }
 
-    private static String extractExtension(String fileName) {
+    private static Optional<ImageContentType> findByFileName(String fileName) {
         String extension = StringUtils.getFilenameExtension(fileName);
         if (extension == null || extension.isBlank()) {
-            throw new BaseException("파일 확장자를 확인할 수 없습니다: " + fileName);
+            return Optional.empty();
         }
-        return extension.toLowerCase();
+        String normalized = extension.toLowerCase();
+        return Arrays.stream(values())
+            .filter(type -> type.extensions.contains(normalized))
+            .findFirst();
     }
 }

--- a/src/main/java/com/forgather/domain/upload/domain/SignedUrlIssuer.java
+++ b/src/main/java/com/forgather/domain/upload/domain/SignedUrlIssuer.java
@@ -48,9 +48,6 @@ public class SignedUrlIssuer {
         return signedUrls;
     }
 
-    /**
-     * 전시 사진 presigned URL을 발급한다.
-     */
     public Map<String, String> issueForExhibition(List<UploadFile> uploadFiles, Long hostId) {
         validateNotEmpty(uploadFiles);
         validateCount(uploadFiles);
@@ -75,6 +72,8 @@ public class SignedUrlIssuer {
         );
     }
 
+    @Deprecated(forRemoval = true)
+    @SuppressWarnings("removal")
     public Map<String, String> issueSignedUrls(
         List<String> uploadFileNames,
         String spaceCode,

--- a/src/main/java/com/forgather/domain/upload/domain/SignedUrlIssuer.java
+++ b/src/main/java/com/forgather/domain/upload/domain/SignedUrlIssuer.java
@@ -21,71 +21,98 @@ public class SignedUrlIssuer {
 
     private final ContentsStorage contentsStorage;
 
-    public Map<String, String> issueSignedUrls(
-        List<String> uploadFileNames,
+    public Map<String, String> issueForSpace(
+        List<UploadFile> uploadFiles,
         String spaceCode,
         UploadCategory category
     ) {
-        if (uploadFileNames == null || uploadFileNames.isEmpty()) {
-            throw new BaseException("업로드 파일명 목록은 null이거나 비어있을 수 없습니다.");
-        }
+        validateNotEmpty(uploadFiles);
+        validateCount(uploadFiles);
+
         if (spaceCode == null || spaceCode.isEmpty()) {
             throw new BaseException("스페이스 코드는 null이거나 비어있을 수 없습니다.");
         }
         if (category == null) {
             throw new BaseException("업로드 카테고리는 필수입니다.");
         }
-        validateSize(uploadFileNames);
         Map<String, String> signedUrls = new HashMap<>();
-        for (String uploadFileName : uploadFileNames) {
-            String filePath = getFilePath(spaceCode, category, uploadFileName);
-            String signedUrl = contentsStorage.issueSignedUrl(filePath);
-            signedUrls.put(uploadFileName, signedUrl);
+        for (UploadFile uploadFile : uploadFiles) {
+            String filePath = generateContentsFilePath(
+                contentsStorage.getRootDirectory(),
+                spaceCode,
+                category,
+                uploadFile.getFileName()
+            );
+            signedUrls.put(uploadFile.getFileName(), issueUploadUrl(filePath, uploadFile));
         }
         return signedUrls;
+    }
+
+    /**
+     * 전시 사진 presigned URL을 발급한다.
+     */
+    public Map<String, String> issueForExhibition(List<UploadFile> uploadFiles, Long hostId) {
+        validateNotEmpty(uploadFiles);
+        validateCount(uploadFiles);
+
+        Map<String, String> signedUrls = new HashMap<>();
+        for (UploadFile uploadFile : uploadFiles) {
+            String filePath = generateExhibitionContentsFilePath(
+                contentsStorage.getRootDirectory(),
+                hostId,
+                uploadFile.getFileName()
+            );
+            signedUrls.put(uploadFile.getFileName(), issueUploadUrl(filePath, uploadFile));
+        }
+        return signedUrls;
+    }
+
+    private String issueUploadUrl(String filePath, UploadFile uploadFile) {
+        return contentsStorage.issueSignedUrl(
+            filePath,
+            uploadFile.getContentType(),
+            uploadFile.getSize()
+        );
     }
 
     public Map<String, String> issueSignedUrls(
         List<String> uploadFileNames,
-        UploadCategory category,
-        Long hostId
+        String spaceCode,
+        UploadCategory category
     ) {
-        if (uploadFileNames == null || uploadFileNames.isEmpty()) {
-            throw new BaseException("업로드 파일명 목록은 null이거나 비어있을 수 없습니다.");
+        validateNotEmpty(uploadFileNames);
+        if (spaceCode == null || spaceCode.isEmpty()) {
+            throw new BaseException("스페이스 코드는 null이거나 비어있을 수 없습니다.");
         }
         if (category == null) {
             throw new BaseException("업로드 카테고리는 필수입니다.");
         }
-        validateSize(uploadFileNames);
-
+        validateCount(uploadFileNames);
         Map<String, String> signedUrls = new HashMap<>();
         for (String uploadFileName : uploadFileNames) {
-            String filePath = generateExhibitionContentsFilePath(
+            if (uploadFileName == null || uploadFileName.isBlank()) {
+                throw new BaseException("업로드 파일명은 null이거나 비어있을 수 없습니다.");
+            }
+            String filePath = generateContentsFilePath(
                 contentsStorage.getRootDirectory(),
-                hostId,
+                spaceCode,
+                category,
                 uploadFileName
             );
-            String signedUrl = contentsStorage.issueSignedUrl(filePath);
-            signedUrls.put(uploadFileName, signedUrl);
+            signedUrls.put(uploadFileName, contentsStorage.issueSignedUrl(filePath));
         }
         return signedUrls;
     }
 
-    private void validateSize(List<String> uploadFileNames) {
-        if (uploadFileNames.size() > MAX_COUNT_PER_ISSUE) {
-            throw new BaseException("한번에 발급 가능한 업로드 url 개수는 %d개 입니다.".formatted(MAX_COUNT_PER_ISSUE));
+    private void validateNotEmpty(List<?> uploadFiles) {
+        if (uploadFiles == null || uploadFiles.isEmpty()) {
+            throw new BaseException("업로드 파일명 목록은 null이거나 비어있을 수 없습니다.");
         }
     }
 
-    private String getFilePath(String spaceCode, UploadCategory category, String uploadFileName) {
-        if (uploadFileName == null || uploadFileName.isEmpty()) {
-            throw new BaseException("업로드 파일명은 null이거나 비어있을 수 없습니다.");
+    private void validateCount(List<?> uploadFiles) {
+        if (uploadFiles.size() > MAX_COUNT_PER_ISSUE) {
+            throw new BaseException("한번에 발급 가능한 업로드 url 개수는 %d개 입니다.".formatted(MAX_COUNT_PER_ISSUE));
         }
-        return generateContentsFilePath(
-            contentsStorage.getRootDirectory(),
-            spaceCode,
-            category,
-            uploadFileName
-        );
     }
 }

--- a/src/main/java/com/forgather/domain/upload/domain/SignedUrlIssuer.java
+++ b/src/main/java/com/forgather/domain/upload/domain/SignedUrlIssuer.java
@@ -22,7 +22,7 @@ public class SignedUrlIssuer {
     private final ContentsStorage contentsStorage;
 
     public Map<String, String> issueForSpace(
-        List<UploadFile> uploadFiles,
+        List<UploadFileMetadata> uploadFiles,
         String spaceCode,
         UploadCategory category
     ) {
@@ -36,7 +36,7 @@ public class SignedUrlIssuer {
             throw new BaseException("업로드 카테고리는 필수입니다.");
         }
         Map<String, String> signedUrls = new HashMap<>();
-        for (UploadFile uploadFile : uploadFiles) {
+        for (UploadFileMetadata uploadFile : uploadFiles) {
             String filePath = generateContentsFilePath(
                 contentsStorage.getRootDirectory(),
                 spaceCode,
@@ -48,12 +48,12 @@ public class SignedUrlIssuer {
         return signedUrls;
     }
 
-    public Map<String, String> issueForExhibition(List<UploadFile> uploadFiles) {
+    public Map<String, String> issueForExhibition(List<UploadFileMetadata> uploadFiles) {
         validateNotEmpty(uploadFiles);
         validateCount(uploadFiles);
 
         Map<String, String> signedUrls = new HashMap<>();
-        for (UploadFile uploadFile : uploadFiles) {
+        for (UploadFileMetadata uploadFile : uploadFiles) {
             String filePath = generateExhibitionContentsFilePath(
                 contentsStorage.getRootDirectory(),
                 uploadFile.getFileName()
@@ -63,7 +63,7 @@ public class SignedUrlIssuer {
         return signedUrls;
     }
 
-    private String issueUploadUrl(String filePath, UploadFile uploadFile) {
+    private String issueUploadUrl(String filePath, UploadFileMetadata uploadFile) {
         return contentsStorage.issueSignedUrl(
             filePath,
             uploadFile.getContentType(),

--- a/src/main/java/com/forgather/domain/upload/domain/SignedUrlIssuer.java
+++ b/src/main/java/com/forgather/domain/upload/domain/SignedUrlIssuer.java
@@ -45,7 +45,11 @@ public class SignedUrlIssuer {
         return signedUrls;
     }
 
-    public Map<String, String> issueSignedUrls(List<String> uploadFileNames, UploadCategory category, long hostId) {
+    public Map<String, String> issueSignedUrls(
+        List<String> uploadFileNames,
+        UploadCategory category,
+        Long hostId
+    ) {
         if (uploadFileNames == null || uploadFileNames.isEmpty()) {
             throw new BaseException("업로드 파일명 목록은 null이거나 비어있을 수 없습니다.");
         }

--- a/src/main/java/com/forgather/domain/upload/domain/SignedUrlIssuer.java
+++ b/src/main/java/com/forgather/domain/upload/domain/SignedUrlIssuer.java
@@ -1,6 +1,7 @@
 package com.forgather.domain.upload.domain;
 
 import static com.forgather.domain.upload.domain.FilePathGenerator.generateContentsFilePath;
+import static com.forgather.domain.upload.domain.FilePathGenerator.generateExhibitionContentsFilePath;
 
 import java.util.HashMap;
 import java.util.List;
@@ -38,6 +39,28 @@ public class SignedUrlIssuer {
         Map<String, String> signedUrls = new HashMap<>();
         for (String uploadFileName : uploadFileNames) {
             String filePath = getFilePath(spaceCode, category, uploadFileName);
+            String signedUrl = contentsStorage.issueSignedUrl(filePath);
+            signedUrls.put(uploadFileName, signedUrl);
+        }
+        return signedUrls;
+    }
+
+    public Map<String, String> issueSignedUrls(List<String> uploadFileNames, UploadCategory category, long hostId) {
+        if (uploadFileNames == null || uploadFileNames.isEmpty()) {
+            throw new BaseException("업로드 파일명 목록은 null이거나 비어있을 수 없습니다.");
+        }
+        if (category == null) {
+            throw new BaseException("업로드 카테고리는 필수입니다.");
+        }
+        validateSize(uploadFileNames);
+
+        Map<String, String> signedUrls = new HashMap<>();
+        for (String uploadFileName : uploadFileNames) {
+            String filePath = generateExhibitionContentsFilePath(
+                contentsStorage.getRootDirectory(),
+                hostId,
+                uploadFileName
+            );
             String signedUrl = contentsStorage.issueSignedUrl(filePath);
             signedUrls.put(uploadFileName, signedUrl);
         }

--- a/src/main/java/com/forgather/domain/upload/domain/SignedUrlIssuer.java
+++ b/src/main/java/com/forgather/domain/upload/domain/SignedUrlIssuer.java
@@ -48,7 +48,7 @@ public class SignedUrlIssuer {
         return signedUrls;
     }
 
-    public Map<String, String> issueForExhibition(List<UploadFile> uploadFiles, Long hostId) {
+    public Map<String, String> issueForExhibition(List<UploadFile> uploadFiles) {
         validateNotEmpty(uploadFiles);
         validateCount(uploadFiles);
 
@@ -56,7 +56,6 @@ public class SignedUrlIssuer {
         for (UploadFile uploadFile : uploadFiles) {
             String filePath = generateExhibitionContentsFilePath(
                 contentsStorage.getRootDirectory(),
-                hostId,
                 uploadFile.getFileName()
             );
             signedUrls.put(uploadFile.getFileName(), issueUploadUrl(filePath, uploadFile));

--- a/src/main/java/com/forgather/domain/upload/domain/UploadCategory.java
+++ b/src/main/java/com/forgather/domain/upload/domain/UploadCategory.java
@@ -3,7 +3,8 @@ package com.forgather.domain.upload.domain;
 public enum UploadCategory {
     PRODUCT,
     GUESTBOOK,
-    SPACE
+    SPACE,
+    EXHIBITION,
     ;
 
     @Override

--- a/src/main/java/com/forgather/domain/upload/domain/UploadFile.java
+++ b/src/main/java/com/forgather/domain/upload/domain/UploadFile.java
@@ -1,0 +1,46 @@
+package com.forgather.domain.upload.domain;
+
+import com.forgather.global.exception.BaseException;
+
+/**
+ * presigned URL을 발급할 업로드 파일 한 건의 도메인 값 객체.
+ * 파일명 형식과 크기 상한(최대 {@link #MAX_FILE_SIZE_BYTES})을 스스로 보장하고,
+ * 파일명 확장자로부터 고정할 Content-Type을 제공한다.
+ */
+public class UploadFile {
+
+    public static final long MAX_FILE_SIZE_BYTES = 20L * 1024 * 1024; // 20MB
+
+    private final String fileName;
+    private final long size;
+
+    public UploadFile(String fileName, long size) {
+        UploadFileNamePolicy.validate(fileName);
+        validateSize(fileName, size);
+        this.fileName = fileName;
+        this.size = size;
+    }
+
+    private static void validateSize(String fileName, long size) {
+        if (size <= 0) {
+            throw new BaseException("업로드 파일 크기는 0보다 커야 합니다: " + fileName);
+        }
+        if (size > MAX_FILE_SIZE_BYTES) {
+            throw new BaseException(
+                "업로드 파일 크기는 최대 %dMB 입니다: %s".formatted(MAX_FILE_SIZE_BYTES / 1024 / 1024, fileName)
+            );
+        }
+    }
+
+    public String getContentType() {
+        return ImageContentType.resolveByFileName(fileName);
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public long getSize() {
+        return size;
+    }
+}

--- a/src/main/java/com/forgather/domain/upload/domain/UploadFile.java
+++ b/src/main/java/com/forgather/domain/upload/domain/UploadFile.java
@@ -2,11 +2,14 @@ package com.forgather.domain.upload.domain;
 
 import com.forgather.global.exception.BaseException;
 
+import lombok.Getter;
+
 /**
  * presigned URL을 발급할 업로드 파일 한 건의 도메인 값 객체.
  * 파일명 형식과 크기 상한(최대 {@link #MAX_FILE_SIZE_BYTES})을 스스로 보장하고,
  * 파일명 확장자로부터 고정할 Content-Type을 제공한다.
  */
+@Getter
 public class UploadFile {
 
     public static final long MAX_FILE_SIZE_BYTES = 20L * 1024 * 1024; // 20MB
@@ -34,13 +37,5 @@ public class UploadFile {
 
     public String getContentType() {
         return ImageContentType.resolveByFileName(fileName);
-    }
-
-    public String getFileName() {
-        return fileName;
-    }
-
-    public long getSize() {
-        return size;
     }
 }

--- a/src/main/java/com/forgather/domain/upload/domain/UploadFileMetadata.java
+++ b/src/main/java/com/forgather/domain/upload/domain/UploadFileMetadata.java
@@ -5,19 +5,20 @@ import com.forgather.global.exception.BaseException;
 import lombok.Getter;
 
 /**
- * presigned URL을 발급할 업로드 파일 한 건의 도메인 값 객체.
+ * presigned URL 발급에 필요한 업로드 파일 한 건의 메타데이터(파일명·크기) 값 객체.
+ * 실제 파일 바이트가 아니라 업로드할 파일의 명세를 표현한다.
  * 파일명 형식과 크기 상한(최대 {@link #MAX_FILE_SIZE_BYTES})을 스스로 보장하고,
  * 파일명 확장자로부터 고정할 Content-Type을 제공한다.
  */
 @Getter
-public class UploadFile {
+public class UploadFileMetadata {
 
     public static final long MAX_FILE_SIZE_BYTES = 20L * 1024 * 1024; // 20MB
 
     private final String fileName;
     private final long size;
 
-    public UploadFile(String fileName, long size) {
+    public UploadFileMetadata(String fileName, long size) {
         UploadFileNamePolicy.validate(fileName);
         validateSize(fileName, size);
         this.fileName = fileName;

--- a/src/main/java/com/forgather/domain/upload/domain/UploadFileNamePolicy.java
+++ b/src/main/java/com/forgather/domain/upload/domain/UploadFileNamePolicy.java
@@ -8,7 +8,6 @@ import com.forgather.global.exception.BaseException;
 public class UploadFileNamePolicy {
 
     public static final String FILENAME_PATTERN = "^[^/\\\\]+\\.(jpg|jpeg|png|webp)$";
-
     private static final Pattern PATTERN = Pattern.compile(FILENAME_PATTERN);
 
     private UploadFileNamePolicy() {

--- a/src/main/java/com/forgather/domain/upload/domain/UploadFileNamePolicy.java
+++ b/src/main/java/com/forgather/domain/upload/domain/UploadFileNamePolicy.java
@@ -7,7 +7,7 @@ import com.forgather.global.exception.BaseException;
 
 public class UploadFileNamePolicy {
 
-    public static final String FILENAME_PATTERN = "^[^/\\\\]+\\.(jpg|jpeg|png|webp)$";
+    public static final String FILENAME_PATTERN = "^[^/\\\\]+\\.[a-z0-9]+$";
     private static final Pattern PATTERN = Pattern.compile(FILENAME_PATTERN);
 
     private UploadFileNamePolicy() {
@@ -26,6 +26,9 @@ public class UploadFileNamePolicy {
         }
         if (!PATTERN.matcher(fileName).matches()) {
             throw new BaseException("올바르지 않은 업로드 파일명 형식입니다: " + fileName);
+        }
+        if (!ImageContentType.isSupportedFileName(fileName)) {
+            throw new BaseException("지원하지 않는 이미지 확장자입니다: " + fileName);
         }
     }
 }

--- a/src/main/java/com/forgather/domain/upload/domain/UploadFileNamePolicy.java
+++ b/src/main/java/com/forgather/domain/upload/domain/UploadFileNamePolicy.java
@@ -1,10 +1,14 @@
 package com.forgather.domain.upload.domain;
 
-import java.util.List;
 import java.util.regex.Pattern;
 
 import com.forgather.global.exception.BaseException;
 
+/**
+ * 업로드 파일명 검증 정책. 현재 이미지 전용이며, 형식 검증(종류 무관)과 확장자 검증(종류별)을 분리해 둔다.
+ * 동영상 등 업로드 종류가 늘어나면 이 클래스를 인터페이스로 승격하고
+ * {@link #validateSupportedExtension}을 종류별 구현으로 분리한다.
+ */
 public class UploadFileNamePolicy {
 
     public static final String FILENAME_PATTERN = "^[^/\\\\]+\\.[a-z0-9]+$";
@@ -13,20 +17,21 @@ public class UploadFileNamePolicy {
     private UploadFileNamePolicy() {
     }
 
-    public static void validateAll(List<String> fileNames) {
-        if (fileNames == null) {
-            throw new BaseException("업로드 파일명 목록은 null일 수 없습니다.");
-        }
-        fileNames.forEach(UploadFileNamePolicy::validate);
+    public static void validate(String fileName) {
+        validateNameFormat(fileName);
+        validateSupportedExtension(fileName);
     }
 
-    public static void validate(String fileName) {
+    private static void validateNameFormat(String fileName) {
         if (fileName == null || fileName.isBlank()) {
             throw new BaseException("업로드 파일명은 null이거나 비어있을 수 없습니다.");
         }
         if (!PATTERN.matcher(fileName).matches()) {
             throw new BaseException("올바르지 않은 업로드 파일명 형식입니다: " + fileName);
         }
+    }
+
+    private static void validateSupportedExtension(String fileName) {
         if (!ImageContentType.isSupportedFileName(fileName)) {
             throw new BaseException("지원하지 않는 이미지 확장자입니다: " + fileName);
         }

--- a/src/main/java/com/forgather/domain/upload/domain/UploadFileNamePolicy.java
+++ b/src/main/java/com/forgather/domain/upload/domain/UploadFileNamePolicy.java
@@ -1,0 +1,32 @@
+package com.forgather.domain.upload.domain;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+import com.forgather.global.exception.BaseException;
+
+public class UploadFileNamePolicy {
+
+    public static final String FILENAME_PATTERN = "^[^/\\\\]+\\.(jpg|jpeg|png|webp)$";
+
+    private static final Pattern PATTERN = Pattern.compile(FILENAME_PATTERN);
+
+    private UploadFileNamePolicy() {
+    }
+
+    public static void validateAll(List<String> fileNames) {
+        if (fileNames == null) {
+            throw new BaseException("업로드 파일명 목록은 null일 수 없습니다.");
+        }
+        fileNames.forEach(UploadFileNamePolicy::validate);
+    }
+
+    public static void validate(String fileName) {
+        if (fileName == null || fileName.isBlank()) {
+            throw new BaseException("업로드 파일명은 null이거나 비어있을 수 없습니다.");
+        }
+        if (!PATTERN.matcher(fileName).matches()) {
+            throw new BaseException("올바르지 않은 업로드 파일명 형식입니다: " + fileName);
+        }
+    }
+}

--- a/src/main/java/com/forgather/domain/upload/dto/IssuePreSignedUrlRequest.java
+++ b/src/main/java/com/forgather/domain/upload/dto/IssuePreSignedUrlRequest.java
@@ -19,7 +19,7 @@ public record IssuePreSignedUrlRequest(
     @NotEmpty
     @Valid
     @Schema(description = "업로드 파일 목록")
-    List<UploadFileRequest> uploadFiles
+    List<@NotNull(message = "업로드 파일은 null일 수 없습니다.") UploadFileRequest> uploadFiles
 ) {
 
     public List<UploadFileMetadata> toUploadFilesData() {

--- a/src/main/java/com/forgather/domain/upload/dto/IssuePreSignedUrlRequest.java
+++ b/src/main/java/com/forgather/domain/upload/dto/IssuePreSignedUrlRequest.java
@@ -1,0 +1,14 @@
+package com.forgather.domain.upload.dto;
+
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+
+public record IssuePreSignedUrlRequest(
+
+    @NotEmpty
+    @Schema(description = "업로드 파일 이름 목록", example = "[\"UUID1.png\", \"UUID2.jpeg\", \"UUID3.png\"]")
+    List<String> uploadFileNames
+) {
+}

--- a/src/main/java/com/forgather/domain/upload/dto/IssuePreSignedUrlRequest.java
+++ b/src/main/java/com/forgather/domain/upload/dto/IssuePreSignedUrlRequest.java
@@ -2,7 +2,7 @@ package com.forgather.domain.upload.dto;
 
 import java.util.List;
 
-import com.forgather.domain.upload.domain.UploadFile;
+import com.forgather.domain.upload.domain.UploadFileMetadata;
 import com.forgather.domain.upload.domain.UploadFileNamePolicy;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -22,7 +22,7 @@ public record IssuePreSignedUrlRequest(
     List<UploadFileRequest> uploadFiles
 ) {
 
-    public List<UploadFile> toUploadFiles() {
+    public List<UploadFileMetadata> toUploadFilesData() {
         return uploadFiles.stream()
             .map(UploadFileRequest::toDomain)
             .toList();
@@ -40,13 +40,13 @@ public record IssuePreSignedUrlRequest(
 
         @NotNull
         @Positive
-        @Max(value = UploadFile.MAX_FILE_SIZE_BYTES, message = "업로드 파일 크기는 최대 20MB 입니다.")
+        @Max(value = UploadFileMetadata.MAX_FILE_SIZE_BYTES, message = "업로드 파일 크기는 최대 20MB 입니다.")
         @Schema(description = "업로드 파일 크기 (바이트)", example = "1048576")
         Long size
     ) {
 
-        public UploadFile toDomain() {
-            return new UploadFile(fileName, size);
+        public UploadFileMetadata toDomain() {
+            return new UploadFileMetadata(fileName, size);
         }
     }
 }

--- a/src/main/java/com/forgather/domain/upload/dto/IssuePreSignedUrlRequest.java
+++ b/src/main/java/com/forgather/domain/upload/dto/IssuePreSignedUrlRequest.java
@@ -2,13 +2,23 @@ package com.forgather.domain.upload.dto;
 
 import java.util.List;
 
+import com.forgather.domain.upload.domain.UploadFileNamePolicy;
+
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
 
 public record IssuePreSignedUrlRequest(
 
     @NotEmpty
     @Schema(description = "업로드 파일 이름 목록", example = "[\"UUID1.png\", \"UUID2.jpeg\", \"UUID3.png\"]")
-    List<String> uploadFileNames
+    List<
+        @NotBlank
+        @Pattern(
+            regexp = UploadFileNamePolicy.FILENAME_PATTERN,
+            message = "올바르지 않은 업로드 파일명 형식입니다."
+        ) String>
+    uploadFileNames
 ) {
 }

--- a/src/main/java/com/forgather/domain/upload/dto/IssuePreSignedUrlRequest.java
+++ b/src/main/java/com/forgather/domain/upload/dto/IssuePreSignedUrlRequest.java
@@ -35,7 +35,7 @@ public record IssuePreSignedUrlRequest(
             regexp = UploadFileNamePolicy.FILENAME_PATTERN,
             message = "올바르지 않은 업로드 파일명 형식입니다."
         )
-        @Schema(description = "업로드 파일 이름 (UUID.확장자)", example = "UUID1.png")
+        @Schema(description = "업로드 파일 이름 (UUID.확장자)", example = "UUID1.webp")
         String fileName,
 
         @NotNull

--- a/src/main/java/com/forgather/domain/upload/dto/IssuePreSignedUrlRequest.java
+++ b/src/main/java/com/forgather/domain/upload/dto/IssuePreSignedUrlRequest.java
@@ -2,23 +2,51 @@ package com.forgather.domain.upload.dto;
 
 import java.util.List;
 
+import com.forgather.domain.upload.domain.UploadFile;
 import com.forgather.domain.upload.domain.UploadFileNamePolicy;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
 
 public record IssuePreSignedUrlRequest(
 
     @NotEmpty
-    @Schema(description = "업로드 파일 이름 목록", example = "[\"UUID1.png\", \"UUID2.jpeg\", \"UUID3.png\"]")
-    List<
+    @Valid
+    @Schema(description = "업로드 파일 목록")
+    List<UploadFileRequest> uploadFiles
+) {
+
+    public List<UploadFile> toUploadFiles() {
+        return uploadFiles.stream()
+            .map(UploadFileRequest::toDomain)
+            .toList();
+    }
+
+    public record UploadFileRequest(
+
         @NotBlank
         @Pattern(
             regexp = UploadFileNamePolicy.FILENAME_PATTERN,
             message = "올바르지 않은 업로드 파일명 형식입니다."
-        ) String>
-    uploadFileNames
-) {
+        )
+        @Schema(description = "업로드 파일 이름 (UUID.확장자)", example = "UUID1.png")
+        String fileName,
+
+        @NotNull
+        @Positive
+        @Max(value = UploadFile.MAX_FILE_SIZE_BYTES, message = "업로드 파일 크기는 최대 20MB 입니다.")
+        @Schema(description = "업로드 파일 크기 (바이트)", example = "1048576")
+        Long size
+    ) {
+
+        public UploadFile toDomain() {
+            return new UploadFile(fileName, size);
+        }
+    }
 }

--- a/src/main/java/com/forgather/domain/upload/dto/IssueSignedUrlResponse.java
+++ b/src/main/java/com/forgather/domain/upload/dto/IssueSignedUrlResponse.java
@@ -8,8 +8,8 @@ public record IssueSignedUrlResponse(
 
     @Schema(description = "서명된 URL 목록", example = """
         {
-            "UUID1.png": "https://my-bucket.s3.ap-northeast-2.amazonaws.com/UUID1.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=EXAMPLE...",
-            "UUID2.jpg": "https://my-bucket.s3.ap-northeast-2.amazonaws.com/UUID2.jpg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=EXAMPLE..."
+            "UUID1.webp": "https://my-bucket.s3.ap-northeast-2.amazonaws.com/UUID1.webp?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=EXAMPLE...",
+            "UUID2.webp": "https://my-bucket.s3.ap-northeast-2.amazonaws.com/UUID2.webp?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=EXAMPLE..."
         }
         """)
     Map<String, String> signedUrls

--- a/src/main/java/com/forgather/domain/upload/service/UploadService.java
+++ b/src/main/java/com/forgather/domain/upload/service/UploadService.java
@@ -55,7 +55,8 @@ public class UploadService {
         }
     }
 
-    // TODO: 추후 제거
+    @Deprecated(forRemoval = true)
+    @SuppressWarnings("removal")
     @Transactional(readOnly = true)
     public IssueSignedUrlResponse issueSignedUrls(String spaceCode, IssueSignedUrlRequest request) {
         spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);

--- a/src/main/java/com/forgather/domain/upload/service/UploadService.java
+++ b/src/main/java/com/forgather/domain/upload/service/UploadService.java
@@ -11,6 +11,7 @@ import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.domain.ContentsStorage;
 import com.forgather.domain.upload.domain.SignedUrlIssuer;
 import com.forgather.domain.upload.domain.UploadCategory;
+import com.forgather.domain.upload.domain.UploadFileNamePolicy;
 import com.forgather.domain.upload.dto.IssuePreSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlResponse;
@@ -64,6 +65,7 @@ public class UploadService {
     }
 
     public IssueSignedUrlResponse issueGuestbookSignedUrls(String spaceCode, IssuePreSignedUrlRequest request) {
+        UploadFileNamePolicy.validateAll(request.uploadFileNames());
         spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
 
         Map<String, String> signedUrls = signedUrlIssuer.issueSignedUrls(
@@ -79,6 +81,7 @@ public class UploadService {
         Host host,
         IssuePreSignedUrlRequest request
     ) {
+        UploadFileNamePolicy.validateAll(request.uploadFileNames());
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateSpaceHost(space, host);
 
@@ -98,6 +101,7 @@ public class UploadService {
     }
 
     public IssueSignedUrlResponse issueExhibitionSignedUrls(Host host, IssuePreSignedUrlRequest request) {
+        UploadFileNamePolicy.validateAll(request.uploadFileNames());
         Map<String, String> signedUrls = signedUrlIssuer.issueSignedUrls(
             request.uploadFileNames(),
             UploadCategory.EXHIBITION,

--- a/src/main/java/com/forgather/domain/upload/service/UploadService.java
+++ b/src/main/java/com/forgather/domain/upload/service/UploadService.java
@@ -38,18 +38,18 @@ public class UploadService {
     public String upload(String spaceCode, MultipartFile file) {
         try {
             long startMillis = System.currentTimeMillis();
-            log.info("파일 업로드 시작 spaceCode: {}, originalName: {}, getSize: {}",
+            log.info("파일 업로드 시작 spaceCode: {}, originalName: {}, size: {}",
                 spaceCode, file.getOriginalFilename(), file.getSize());
 
             String path = contentsStorage.upload(spaceCode, file);
 
             long durationMillis = System.currentTimeMillis() - startMillis;
-            log.info("파일 업로드 완료 spaceCode: {}, originalName: {}, getSize: {}, path: {}, duration: {}",
+            log.info("파일 업로드 완료 spaceCode: {}, originalName: {}, size: {}, path: {}, duration: {}",
                 spaceCode, file.getOriginalFilename(), file.getSize(), path, durationMillis + "ms");
 
             return path;
         } catch (IOException e) {
-            throw new FileUploadException("파일 업로드 실패 spaceCode: %s, originalName: %s, getSize: %d".formatted(
+            throw new FileUploadException("파일 업로드 실패 spaceCode: %s, originalName: %s, size: %d".formatted(
                 spaceCode, file.getOriginalFilename(), file.getSize()
             ), e);
         }

--- a/src/main/java/com/forgather/domain/upload/service/UploadService.java
+++ b/src/main/java/com/forgather/domain/upload/service/UploadService.java
@@ -52,8 +52,23 @@ public class UploadService {
         }
     }
 
+    // TODO: 추후 제거
     public IssueSignedUrlResponse issueSignedUrls(String spaceCode, IssueSignedUrlRequest request) {
         spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
+        Map<String, String> signedUrls = signedUrlIssuer.issueSignedUrls(
+            request.uploadFileNames(),
+            spaceCode,
+            request.category()
+        );
+        return new IssueSignedUrlResponse(signedUrls);
+    }
+
+    public IssueSignedUrlResponse issueGuestbookSignedUrls(String spaceCode, IssueSignedUrlRequest request) {
+        if (request.category() != UploadCategory.GUESTBOOK) {
+            throw new BaseException("게스트북 업로드는 GUESTBOOK 카테고리만 지원합니다.");
+        }
+        spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
+
         Map<String, String> signedUrls = signedUrlIssuer.issueSignedUrls(
             request.uploadFileNames(),
             spaceCode,

--- a/src/main/java/com/forgather/domain/upload/service/UploadService.java
+++ b/src/main/java/com/forgather/domain/upload/service/UploadService.java
@@ -6,13 +6,18 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.domain.ContentsStorage;
 import com.forgather.domain.upload.domain.SignedUrlIssuer;
+import com.forgather.domain.upload.domain.UploadCategory;
 import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlResponse;
 import com.forgather.global.auth.model.Host;
+import com.forgather.global.auth.repository.SpaceHostRepository;
+import com.forgather.global.exception.BaseException;
 import com.forgather.global.exception.FileUploadException;
+import com.forgather.global.exception.ForbiddenException;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 public class UploadService {
 
     private final SpaceRepository spaceRepository;
+    private final SpaceHostRepository spaceHostRepository;
     private final ContentsStorage contentsStorage;
     private final SignedUrlIssuer signedUrlIssuer;
 
@@ -54,6 +60,28 @@ public class UploadService {
             request.category()
         );
         return new IssueSignedUrlResponse(signedUrls);
+    }
+
+    public IssueSignedUrlResponse issueProductSignedUrls(String spaceCode, Host host, IssueSignedUrlRequest request) {
+        if (request.category() != UploadCategory.PRODUCT) {
+            throw new BaseException("작품 업로드는 PRODUCT 카테고리만 지원합니다.");
+        }
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
+        validateSpaceHost(space, host);
+
+        Map<String, String> signedUrls = signedUrlIssuer.issueSignedUrls(
+            request.uploadFileNames(),
+            spaceCode,
+            request.category()
+        );
+        return new IssueSignedUrlResponse(signedUrls);
+    }
+
+    private void validateSpaceHost(Space space, Host host) {
+        if (spaceHostRepository.findBySpaceAndHostAndDeletedAtIsNull(space, host).isPresent()) {
+            return;
+        }
+        throw new ForbiddenException("권한이 존재하지 않습니다.");
     }
 
     public IssueSignedUrlResponse issueExhibitionSignedUrls(Host host, IssueSignedUrlRequest request) {

--- a/src/main/java/com/forgather/domain/upload/service/UploadService.java
+++ b/src/main/java/com/forgather/domain/upload/service/UploadService.java
@@ -1,6 +1,7 @@
 package com.forgather.domain.upload.service;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
@@ -11,7 +12,7 @@ import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.domain.ContentsStorage;
 import com.forgather.domain.upload.domain.SignedUrlIssuer;
 import com.forgather.domain.upload.domain.UploadCategory;
-import com.forgather.domain.upload.domain.UploadFileNamePolicy;
+import com.forgather.domain.upload.domain.UploadFile;
 import com.forgather.domain.upload.dto.IssuePreSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlResponse;
@@ -36,18 +37,18 @@ public class UploadService {
     public String upload(String spaceCode, MultipartFile file) {
         try {
             long startMillis = System.currentTimeMillis();
-            log.info("파일 업로드 시작 spaceCode: {}, originalName: {}, size: {}",
+            log.info("파일 업로드 시작 spaceCode: {}, originalName: {}, getSize: {}",
                 spaceCode, file.getOriginalFilename(), file.getSize());
 
             String path = contentsStorage.upload(spaceCode, file);
 
             long durationMillis = System.currentTimeMillis() - startMillis;
-            log.info("파일 업로드 완료 spaceCode: {}, originalName: {}, size: {}, path: {}, duration: {}",
+            log.info("파일 업로드 완료 spaceCode: {}, originalName: {}, getSize: {}, path: {}, duration: {}",
                 spaceCode, file.getOriginalFilename(), file.getSize(), path, durationMillis + "ms");
 
             return path;
         } catch (IOException e) {
-            throw new FileUploadException("파일 업로드 실패 spaceCode: %s, originalName: %s, size: %d".formatted(
+            throw new FileUploadException("파일 업로드 실패 spaceCode: %s, originalName: %s, getSize: %d".formatted(
                 spaceCode, file.getOriginalFilename(), file.getSize()
             ), e);
         }
@@ -65,11 +66,11 @@ public class UploadService {
     }
 
     public IssueSignedUrlResponse issueGuestbookSignedUrls(String spaceCode, IssuePreSignedUrlRequest request) {
-        UploadFileNamePolicy.validateAll(request.uploadFileNames());
+        List<UploadFile> uploadFiles = request.toUploadFiles();
         spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
 
-        Map<String, String> signedUrls = signedUrlIssuer.issueSignedUrls(
-            request.uploadFileNames(),
+        Map<String, String> signedUrls = signedUrlIssuer.issueForSpace(
+            uploadFiles,
             spaceCode,
             UploadCategory.GUESTBOOK
         );
@@ -81,12 +82,11 @@ public class UploadService {
         Host host,
         IssuePreSignedUrlRequest request
     ) {
-        UploadFileNamePolicy.validateAll(request.uploadFileNames());
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateSpaceHost(space, host);
 
-        Map<String, String> signedUrls = signedUrlIssuer.issueSignedUrls(
-            request.uploadFileNames(),
+        Map<String, String> signedUrls = signedUrlIssuer.issueForSpace(
+            request.toUploadFiles(),
             spaceCode,
             UploadCategory.PRODUCT
         );
@@ -101,10 +101,8 @@ public class UploadService {
     }
 
     public IssueSignedUrlResponse issueExhibitionSignedUrls(Host host, IssuePreSignedUrlRequest request) {
-        UploadFileNamePolicy.validateAll(request.uploadFileNames());
-        Map<String, String> signedUrls = signedUrlIssuer.issueSignedUrls(
-            request.uploadFileNames(),
-            UploadCategory.EXHIBITION,
+        Map<String, String> signedUrls = signedUrlIssuer.issueForExhibition(
+            request.toUploadFiles(),
             host.getId()
         );
         return new IssueSignedUrlResponse(signedUrls);

--- a/src/main/java/com/forgather/domain/upload/service/UploadService.java
+++ b/src/main/java/com/forgather/domain/upload/service/UploadService.java
@@ -105,11 +105,8 @@ public class UploadService {
         throw new ForbiddenException("권한이 존재하지 않습니다.");
     }
 
-    public IssueSignedUrlResponse issueExhibitionSignedUrls(Host host, IssuePreSignedUrlRequest request) {
-        Map<String, String> signedUrls = signedUrlIssuer.issueForExhibition(
-            request.toUploadFiles(),
-            host.getId()
-        );
+    public IssueSignedUrlResponse issueExhibitionSignedUrls(IssuePreSignedUrlRequest request) {
+        Map<String, String> signedUrls = signedUrlIssuer.issueForExhibition(request.toUploadFiles());
         return new IssueSignedUrlResponse(signedUrls);
     }
 }

--- a/src/main/java/com/forgather/domain/upload/service/UploadService.java
+++ b/src/main/java/com/forgather/domain/upload/service/UploadService.java
@@ -57,6 +57,10 @@ public class UploadService {
     }
 
     public IssueSignedUrlResponse issueExhibitionSignedUrls(Host host, IssueSignedUrlRequest request) {
+        if (request.category() != UploadCategory.EXHIBITION) {
+            throw new BaseException("전시 업로드는 EXHIBITION 카테고리만 지원합니다.");
+        }
+
         Map<String, String> signedUrls = signedUrlIssuer.issueSignedUrls(
             request.uploadFileNames(),
             request.category(),

--- a/src/main/java/com/forgather/domain/upload/service/UploadService.java
+++ b/src/main/java/com/forgather/domain/upload/service/UploadService.java
@@ -13,7 +13,7 @@ import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.domain.ContentsStorage;
 import com.forgather.domain.upload.domain.SignedUrlIssuer;
 import com.forgather.domain.upload.domain.UploadCategory;
-import com.forgather.domain.upload.domain.UploadFile;
+import com.forgather.domain.upload.domain.UploadFileMetadata;
 import com.forgather.domain.upload.dto.IssuePreSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlResponse;
@@ -70,11 +70,11 @@ public class UploadService {
 
     @Transactional(readOnly = true)
     public IssueSignedUrlResponse issueGuestbookSignedUrls(String spaceCode, IssuePreSignedUrlRequest request) {
-        List<UploadFile> uploadFiles = request.toUploadFiles();
+        List<UploadFileMetadata> uploadFilesData = request.toUploadFilesData();
         spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
 
         Map<String, String> signedUrls = signedUrlIssuer.issueForSpace(
-            uploadFiles,
+            uploadFilesData,
             spaceCode,
             UploadCategory.GUESTBOOK
         );
@@ -91,7 +91,7 @@ public class UploadService {
         validateSpaceHost(space, host);
 
         Map<String, String> signedUrls = signedUrlIssuer.issueForSpace(
-            request.toUploadFiles(),
+            request.toUploadFilesData(),
             spaceCode,
             UploadCategory.PRODUCT
         );
@@ -106,7 +106,7 @@ public class UploadService {
     }
 
     public IssueSignedUrlResponse issueExhibitionSignedUrls(IssuePreSignedUrlRequest request) {
-        Map<String, String> signedUrls = signedUrlIssuer.issueForExhibition(request.toUploadFiles());
+        Map<String, String> signedUrls = signedUrlIssuer.issueForExhibition(request.toUploadFilesData());
         return new IssueSignedUrlResponse(signedUrls);
     }
 }

--- a/src/main/java/com/forgather/domain/upload/service/UploadService.java
+++ b/src/main/java/com/forgather/domain/upload/service/UploadService.java
@@ -6,11 +6,12 @@ import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
-import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
-import com.forgather.domain.upload.dto.IssueSignedUrlResponse;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.domain.ContentsStorage;
 import com.forgather.domain.upload.domain.SignedUrlIssuer;
+import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
+import com.forgather.domain.upload.dto.IssueSignedUrlResponse;
+import com.forgather.global.auth.model.Host;
 import com.forgather.global.exception.FileUploadException;
 
 import lombok.RequiredArgsConstructor;
@@ -51,6 +52,15 @@ public class UploadService {
             request.uploadFileNames(),
             spaceCode,
             request.category()
+        );
+        return new IssueSignedUrlResponse(signedUrls);
+    }
+
+    public IssueSignedUrlResponse issueExhibitionSignedUrls(Host host, IssueSignedUrlRequest request) {
+        Map<String, String> signedUrls = signedUrlIssuer.issueSignedUrls(
+            request.uploadFileNames(),
+            request.category(),
+            host.getId()
         );
         return new IssueSignedUrlResponse(signedUrls);
     }

--- a/src/main/java/com/forgather/domain/upload/service/UploadService.java
+++ b/src/main/java/com/forgather/domain/upload/service/UploadService.java
@@ -11,11 +11,11 @@ import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.domain.ContentsStorage;
 import com.forgather.domain.upload.domain.SignedUrlIssuer;
 import com.forgather.domain.upload.domain.UploadCategory;
+import com.forgather.domain.upload.dto.IssuePreSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlResponse;
 import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.repository.SpaceHostRepository;
-import com.forgather.global.exception.BaseException;
 import com.forgather.global.exception.FileUploadException;
 import com.forgather.global.exception.ForbiddenException;
 
@@ -63,31 +63,29 @@ public class UploadService {
         return new IssueSignedUrlResponse(signedUrls);
     }
 
-    public IssueSignedUrlResponse issueGuestbookSignedUrls(String spaceCode, IssueSignedUrlRequest request) {
-        if (request.category() != UploadCategory.GUESTBOOK) {
-            throw new BaseException("게스트북 업로드는 GUESTBOOK 카테고리만 지원합니다.");
-        }
+    public IssueSignedUrlResponse issueGuestbookSignedUrls(String spaceCode, IssuePreSignedUrlRequest request) {
         spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
 
         Map<String, String> signedUrls = signedUrlIssuer.issueSignedUrls(
             request.uploadFileNames(),
             spaceCode,
-            request.category()
+            UploadCategory.GUESTBOOK
         );
         return new IssueSignedUrlResponse(signedUrls);
     }
 
-    public IssueSignedUrlResponse issueProductSignedUrls(String spaceCode, Host host, IssueSignedUrlRequest request) {
-        if (request.category() != UploadCategory.PRODUCT) {
-            throw new BaseException("작품 업로드는 PRODUCT 카테고리만 지원합니다.");
-        }
+    public IssueSignedUrlResponse issueProductSignedUrls(
+        String spaceCode,
+        Host host,
+        IssuePreSignedUrlRequest request
+    ) {
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         validateSpaceHost(space, host);
 
         Map<String, String> signedUrls = signedUrlIssuer.issueSignedUrls(
             request.uploadFileNames(),
             spaceCode,
-            request.category()
+            UploadCategory.PRODUCT
         );
         return new IssueSignedUrlResponse(signedUrls);
     }
@@ -99,14 +97,10 @@ public class UploadService {
         throw new ForbiddenException("권한이 존재하지 않습니다.");
     }
 
-    public IssueSignedUrlResponse issueExhibitionSignedUrls(Host host, IssueSignedUrlRequest request) {
-        if (request.category() != UploadCategory.EXHIBITION) {
-            throw new BaseException("전시 업로드는 EXHIBITION 카테고리만 지원합니다.");
-        }
-
+    public IssueSignedUrlResponse issueExhibitionSignedUrls(Host host, IssuePreSignedUrlRequest request) {
         Map<String, String> signedUrls = signedUrlIssuer.issueSignedUrls(
             request.uploadFileNames(),
-            request.category(),
+            UploadCategory.EXHIBITION,
             host.getId()
         );
         return new IssueSignedUrlResponse(signedUrls);

--- a/src/main/java/com/forgather/domain/upload/service/UploadService.java
+++ b/src/main/java/com/forgather/domain/upload/service/UploadService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.forgather.domain.space.model.Space;
@@ -55,6 +56,7 @@ public class UploadService {
     }
 
     // TODO: 추후 제거
+    @Transactional(readOnly = true)
     public IssueSignedUrlResponse issueSignedUrls(String spaceCode, IssueSignedUrlRequest request) {
         spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         Map<String, String> signedUrls = signedUrlIssuer.issueSignedUrls(
@@ -65,6 +67,7 @@ public class UploadService {
         return new IssueSignedUrlResponse(signedUrls);
     }
 
+    @Transactional(readOnly = true)
     public IssueSignedUrlResponse issueGuestbookSignedUrls(String spaceCode, IssuePreSignedUrlRequest request) {
         List<UploadFile> uploadFiles = request.toUploadFiles();
         spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
@@ -77,6 +80,7 @@ public class UploadService {
         return new IssueSignedUrlResponse(signedUrls);
     }
 
+    @Transactional(readOnly = true)
     public IssueSignedUrlResponse issueProductSignedUrls(
         String spaceCode,
         Host host,

--- a/src/test/java/com/forgather/acceptance/ExhibitionAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/ExhibitionAcceptanceTest.java
@@ -20,6 +20,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.http.HttpStatus;
 import org.springframework.test.web.servlet.MockMvc;
 
+import com.forgather.domain.exhibition.dto.CreateExhibitionPhotoRequest;
 import com.forgather.domain.exhibition.dto.CreateExhibitionRequest;
 import com.forgather.domain.exhibition.dto.ExhibitionResponse;
 import com.forgather.domain.exhibition.dto.LocationRequest;
@@ -64,8 +65,7 @@ class ExhibitionAcceptanceTest extends AcceptanceTest {
     void createOnlineExhibition() {
         // given
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/spring.webp",
-            1024L,
+            new CreateExhibitionPhotoRequest("spring.webp", 1024L),
             "봄 전시",
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),
@@ -99,7 +99,8 @@ class ExhibitionAcceptanceTest extends AcceptanceTest {
             () -> assertThat(response.message()).isNull(),
             () -> assertThat(response.data().id()).isNotNull(),
             () -> assertThat(response.data().title()).isEqualTo("봄 전시"),
-            () -> assertThat(response.data().representativeImagePath()).isEqualTo("exhibitions/spring.webp"),
+            () -> assertThat(response.data().representativeImagePath())
+                .isEqualTo("ROOT_DIRECTORY_PLACEHOLDER/exhibitions/host-%d/spring.webp".formatted(host.getId())),
             () -> assertThat(response.data().location().locationType()).isEqualTo(LocationType.ONLINE),
             () -> assertThat(response.data().location().url()).isEqualTo("https://forgather.app"),
             () -> assertThat(response.data().operatingHours()).hasSize(2),
@@ -113,8 +114,7 @@ class ExhibitionAcceptanceTest extends AcceptanceTest {
     void createOfflineExhibitionWithoutOperatingHours() {
         // given
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/summer.webp",
-            2048L,
+            new CreateExhibitionPhotoRequest("summer.webp", 2048L),
             "여름 전시",
             LocalDate.of(2026, 7, 1),
             LocalDate.of(2026, 7, 31),
@@ -154,8 +154,7 @@ class ExhibitionAcceptanceTest extends AcceptanceTest {
     void operatingHoursSortedByDayOfWeek() {
         // given
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/sort.webp",
-            1024L,
+            new CreateExhibitionPhotoRequest("sort.webp", 1024L),
             "정렬 검증 전시",
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),
@@ -212,8 +211,7 @@ class ExhibitionAcceptanceTest extends AcceptanceTest {
     void createExhibitionWithoutTitle() {
         // given
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/empty-title.webp",
-            1024L,
+            new CreateExhibitionPhotoRequest("empty-title.webp", 1024L),
             "",
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),
@@ -234,14 +232,13 @@ class ExhibitionAcceptanceTest extends AcceptanceTest {
             .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
-    @DisplayName("이미지 경로가 비어 있으면 전시를 생성할 수 없다.")
+    @DisplayName("업로드 파일명이 비어 있으면 전시를 생성할 수 없다.")
     @Test
-    void createExhibitionWithoutImagePath() {
+    void createExhibitionWithoutUploadFileName() {
         // given
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "",
-            1024L,
-            "빈 이미지 경로 전시",
+            new CreateExhibitionPhotoRequest("", 1024L),
+            "빈 업로드 파일명 전시",
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),
             "전시 설명",
@@ -266,8 +263,7 @@ class ExhibitionAcceptanceTest extends AcceptanceTest {
     void createExhibitionWithDuplicateOperatingDay() {
         // given
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/dup.webp",
-            1024L,
+            new CreateExhibitionPhotoRequest("dup.webp", 1024L),
             "운영시간 요일 중복 전시",
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),
@@ -297,8 +293,7 @@ class ExhibitionAcceptanceTest extends AcceptanceTest {
         String emoji = "🙂";
         String title = emoji.repeat(100);
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/emoji.webp",
-            1024L,
+            new CreateExhibitionPhotoRequest("emoji.webp", 1024L),
             title,
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),
@@ -325,8 +320,7 @@ class ExhibitionAcceptanceTest extends AcceptanceTest {
         String emoji = "🙂";
         String title = emoji.repeat(101);
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/emoji.webp",
-            1024L,
+            new CreateExhibitionPhotoRequest("emoji.webp", 1024L),
             title,
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),
@@ -352,8 +346,7 @@ class ExhibitionAcceptanceTest extends AcceptanceTest {
     void createExhibitionWithTooManyOperatingHours() {
         // given - 고유 요일 7개 + MONDAY 1개 추가로 8개 입력 (Bean Validation의 @Size 위반)
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/too-many.webp",
-            1024L,
+            new CreateExhibitionPhotoRequest("too-many.webp", 1024L),
             "운영시간 초과 전시",
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),
@@ -390,8 +383,7 @@ class ExhibitionAcceptanceTest extends AcceptanceTest {
     void createExhibitionWithNullOperatingHourElement() {
         // given
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/null-element.webp",
-            1024L,
+            new CreateExhibitionPhotoRequest("null-element.webp", 1024L),
             "null 원소 포함 전시",
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),
@@ -419,8 +411,7 @@ class ExhibitionAcceptanceTest extends AcceptanceTest {
 
     private CreateExhibitionRequest createValidRequest() {
         return new CreateExhibitionRequest(
-            "exhibitions/default.webp",
-            1024L,
+            new CreateExhibitionPhotoRequest("default.webp", 1024L),
             "기본 전시",
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),

--- a/src/test/java/com/forgather/acceptance/ExhibitionAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/ExhibitionAcceptanceTest.java
@@ -100,7 +100,7 @@ class ExhibitionAcceptanceTest extends AcceptanceTest {
             () -> assertThat(response.data().id()).isNotNull(),
             () -> assertThat(response.data().title()).isEqualTo("봄 전시"),
             () -> assertThat(response.data().representativeImagePath())
-                .isEqualTo("ROOT_DIRECTORY_PLACEHOLDER/exhibitions/host-%d/spring.webp".formatted(host.getId())),
+                .isEqualTo("ROOT_DIRECTORY_PLACEHOLDER/exhibitions/spring.webp"),
             () -> assertThat(response.data().location().locationType()).isEqualTo(LocationType.ONLINE),
             () -> assertThat(response.data().location().url()).isEqualTo("https://forgather.app"),
             () -> assertThat(response.data().operatingHours()).hasSize(2),

--- a/src/test/java/com/forgather/acceptance/ExhibitionAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/ExhibitionAcceptanceTest.java
@@ -99,7 +99,7 @@ class ExhibitionAcceptanceTest extends AcceptanceTest {
             () -> assertThat(response.message()).isNull(),
             () -> assertThat(response.data().id()).isNotNull(),
             () -> assertThat(response.data().title()).isEqualTo("봄 전시"),
-            () -> assertThat(response.data().representativeImagePath())
+            () -> assertThat(response.data().photoPath())
                 .isEqualTo("ROOT_DIRECTORY_PLACEHOLDER/exhibitions/spring.webp"),
             () -> assertThat(response.data().location().locationType()).isEqualTo(LocationType.ONLINE),
             () -> assertThat(response.data().location().url()).isEqualTo("https://forgather.app"),
@@ -146,6 +146,45 @@ class ExhibitionAcceptanceTest extends AcceptanceTest {
             () -> assertThat(response.data().location().baseAddress()).isEqualTo("서울특별시 송파구"),
             () -> assertThat(response.data().location().detailAddress()).isEqualTo("루터회관"),
             () -> assertThat(response.data().operatingHours()).isNull()
+        );
+    }
+
+    @DisplayName("전시 사진 없이 전시를 생성하면 대표 이미지 경로는 null이다.")
+    @Test
+    void createExhibitionWithoutPhoto() {
+        // given
+        CreateExhibitionRequest request = new CreateExhibitionRequest(
+            null,
+            "사진 없는 전시",
+            LocalDate.of(2026, 6, 1),
+            LocalDate.of(2026, 6, 30),
+            "사진 없이 생성한 전시입니다.",
+            null,
+            null,
+            new LocationRequest(LocationType.ONLINE, "https://forgather.app", null, null)
+        );
+
+        // when
+        ApiResponse<ExhibitionResponse> response = RestAssuredMockMvc.given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(request)
+            .when()
+            .post("/exhibitions")
+            .then()
+            .statusCode(HttpStatus.CREATED.value())
+            .extract()
+            .body()
+            .as(new TypeRef<>() {
+            });
+
+        // then
+        assertAll(
+            () -> assertThat(response.code()).isEqualTo(ResponseCode.SUCCESS),
+            () -> assertThat(response.data().id()).isNotNull(),
+            () -> assertThat(response.data().title()).isEqualTo("사진 없는 전시"),
+            () -> assertThat(response.data().photoPath()).isNull()
         );
     }
 

--- a/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
@@ -149,7 +149,7 @@ class UploadAcceptanceTest extends AcceptanceTest {
         Map<String, String> signedUrls = result.data().signedUrls();
 
         // then
-        String expectedPrefix = "test-prefix-photogather/v2/exhibitions/host-%d/".formatted(host.getId());
+        String expectedPrefix = "test-prefix-photogather/v2/exhibitions/";
         assertAll(
             () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
             () -> assertThat(result.message()).isNull(),

--- a/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
@@ -1,6 +1,5 @@
 package com.forgather.acceptance;
 
-import static com.forgather.domain.upload.domain.UploadCategory.EXHIBITION;
 import static com.forgather.domain.upload.domain.UploadCategory.GUESTBOOK;
 import static com.forgather.fixture.HostFixture.createHost;
 import static com.forgather.fixture.SpaceFixture.createSpace;
@@ -25,6 +24,7 @@ import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.HostRepository;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.AwsS3Cloud;
+import com.forgather.domain.upload.dto.IssuePreSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlResponse;
 import com.forgather.global.auth.model.Host;
@@ -110,7 +110,7 @@ class UploadAcceptanceTest extends AcceptanceTest {
     @Test
     void issueExhibitionSignedUrls() {
         // given
-        IssueSignedUrlRequest request = new IssueSignedUrlRequest(EXHIBITION, List.of("abc.jpg", "def.jpg"));
+        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of("abc.jpg", "def.jpg"));
         when(awsS3Cloud.getRootDirectory()).thenReturn("photogather/v2");
         when(awsS3Cloud.issueSignedUrl(anyString())).thenAnswer(invocation -> {
             String path = invocation.getArgument(0);
@@ -149,7 +149,7 @@ class UploadAcceptanceTest extends AcceptanceTest {
     @Test
     void issueExhibitionSignedUrlsRequiresAuth() {
         // given
-        IssueSignedUrlRequest request = new IssueSignedUrlRequest(EXHIBITION, List.of("abc.jpg"));
+        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of("abc.jpg"));
 
         // when, then
         RestAssuredMockMvc.given()
@@ -160,5 +160,55 @@ class UploadAcceptanceTest extends AcceptanceTest {
             .post("/exhibitions/upload/signed-urls")
             .then()
             .statusCode(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    @DisplayName("전시 사진 서명된 url 발급 시 업로드 파일 이름 목록이 비어있으면 400을 반환한다")
+    @Test
+    void issueExhibitionSignedUrlsWithEmptyFileNames() {
+        // given
+        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of());
+
+        // when
+        ApiResponse<Void> result = RestAssuredMockMvc.given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(request)
+            .when()
+            .post("/exhibitions/upload/signed-urls")
+            .then()
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .extract()
+            .body()
+            .as(new TypeRef<>() {
+            });
+
+        // then
+        assertThat(result.code()).isEqualTo(ResponseCode.VALIDATION_FAILED);
+    }
+
+    @DisplayName("전시 사진 서명된 url 발급 시 업로드 파일 이름 목록이 null이면 400을 반환한다")
+    @Test
+    void issueExhibitionSignedUrlsWithNullFileNames() {
+        // given
+        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(null);
+
+        // when
+        ApiResponse<Void> result = RestAssuredMockMvc.given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(request)
+            .when()
+            .post("/exhibitions/upload/signed-urls")
+            .then()
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .extract()
+            .body()
+            .as(new TypeRef<>() {
+            });
+
+        // then
+        assertThat(result.code()).isEqualTo(ResponseCode.VALIDATION_FAILED);
     }
 }

--- a/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
@@ -5,6 +5,7 @@ import static com.forgather.fixture.HostFixture.createHost;
 import static com.forgather.fixture.SpaceFixture.createSpace;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.when;
 
@@ -27,6 +28,7 @@ import com.forgather.domain.space.repository.HostRepository;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.AwsS3Cloud;
 import com.forgather.domain.upload.dto.IssuePreSignedUrlRequest;
+import com.forgather.domain.upload.dto.IssuePreSignedUrlRequest.UploadFileRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlResponse;
 import com.forgather.global.auth.model.Host;
@@ -112,9 +114,12 @@ class UploadAcceptanceTest extends AcceptanceTest {
     @Test
     void issueExhibitionSignedUrls() {
         // given
-        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of("abc.jpg", "def.jpg"));
+        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
+            new UploadFileRequest("abc.jpg", 1024L),
+            new UploadFileRequest("def.jpg", 2048L)
+        ));
         when(awsS3Cloud.getRootDirectory()).thenReturn("photogather/v2");
-        when(awsS3Cloud.issueSignedUrl(anyString())).thenAnswer(invocation -> {
+        when(awsS3Cloud.issueSignedUrl(anyString(), anyString(), anyLong())).thenAnswer(invocation -> {
             String path = invocation.getArgument(0);
             return "test-prefix-" + path + "-test-suffix";
         });
@@ -151,7 +156,9 @@ class UploadAcceptanceTest extends AcceptanceTest {
     @Test
     void issueExhibitionSignedUrlsRequiresAuth() {
         // given
-        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of("abc.jpg"));
+        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
+            new UploadFileRequest("abc.jpg", 1024L)
+        ));
 
         // when, then
         RestAssuredMockMvc.given()
@@ -219,7 +226,37 @@ class UploadAcceptanceTest extends AcceptanceTest {
     @ValueSource(strings = {"../../../etc/passwd", "a/b.png", "a\\b.png", "noext", "x.gif"})
     void issueExhibitionSignedUrlsWithInvalidFileName(String invalidFileName) {
         // given
-        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(invalidFileName));
+        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
+            new UploadFileRequest(invalidFileName, 1024L)
+        ));
+
+        // when
+        ApiResponse<Void> result = RestAssuredMockMvc.given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(request)
+            .when()
+            .post("/exhibitions/upload/signed-urls")
+            .then()
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .extract()
+            .body()
+            .as(new TypeRef<>() {
+            });
+
+        // then
+        assertThat(result.code()).isEqualTo(ResponseCode.VALIDATION_FAILED);
+    }
+
+    @DisplayName("전시 사진 업로드 url 발급 시 파일 크기가 20MB를 초과하면 400을 반환한다")
+    @Test
+    void issueExhibitionSignedUrlsWithOversizeFile() {
+        // given
+        long oversize = 20L * 1024 * 1024 + 1;
+        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
+            new UploadFileRequest("abc.jpg", oversize)
+        ));
 
         // when
         ApiResponse<Void> result = RestAssuredMockMvc.given()

--- a/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
@@ -30,6 +30,7 @@ import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.HostRepository;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.AwsS3Cloud;
+import com.forgather.domain.upload.domain.UploadFile;
 import com.forgather.domain.upload.dto.IssuePreSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssuePreSignedUrlRequest.UploadFileRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
@@ -126,7 +127,9 @@ class UploadAcceptanceTest extends AcceptanceTest {
         when(awsS3Cloud.getRootDirectory()).thenReturn("photogather/v2");
         when(awsS3Cloud.issueSignedUrl(anyString(), anyString(), anyLong())).thenAnswer(invocation -> {
             String path = invocation.getArgument(0);
-            return "test-prefix-" + path + "-test-suffix";
+            String contentType = invocation.getArgument(1);
+            long contentLength = invocation.getArgument(2);
+            return "test-prefix-" + path + "-" + contentType + "-" + contentLength + "-test-suffix";
         });
 
         // when
@@ -151,9 +154,9 @@ class UploadAcceptanceTest extends AcceptanceTest {
             () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
             () -> assertThat(result.message()).isNull(),
             () -> assertThat(signedUrls.get("abc.webp"))
-                .isEqualTo(expectedPrefix + "abc.webp-test-suffix"),
+                .isEqualTo(expectedPrefix + "abc.webp-image/webp-1024-test-suffix"),
             () -> assertThat(signedUrls.get("def.webp"))
-                .isEqualTo(expectedPrefix + "def.webp-test-suffix")
+                .isEqualTo(expectedPrefix + "def.webp-image/webp-2048-test-suffix")
         );
     }
 
@@ -223,9 +226,72 @@ class UploadAcceptanceTest extends AcceptanceTest {
     @Test
     void issueExhibitionSignedUrlsWithOversizeFile() {
         // given
-        long oversize = 20L * 1024 * 1024 + 1;
+        long oversize = UploadFile.MAX_FILE_SIZE_BYTES + 1;
         IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
             new UploadFileRequest("abc.webp", oversize)
+        ));
+
+        // when
+        ApiResponse<Void> result = postExhibitionSignedUrlsExpectingBadRequest(request);
+
+        // then
+        assertThat(result.code()).isEqualTo(ResponseCode.VALIDATION_FAILED);
+    }
+
+    @DisplayName("전시 사진 업로드 url 발급 시 파일 크기가 정확히 최대치(20MB)이면 발급에 성공한다")
+    @Test
+    void issueExhibitionSignedUrlsWithExactlyMaxSizeFile() {
+        // given
+        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
+            new UploadFileRequest("abc.webp", UploadFile.MAX_FILE_SIZE_BYTES)
+        ));
+        when(awsS3Cloud.getRootDirectory()).thenReturn("photogather/v2");
+        when(awsS3Cloud.issueSignedUrl(anyString(), anyString(), anyLong())).thenAnswer(invocation -> {
+            String path = invocation.getArgument(0);
+            return "test-prefix-" + path + "-test-suffix";
+        });
+
+        // when
+        ApiResponse<IssueSignedUrlResponse> result = RestAssuredMockMvc.given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(request)
+            .when()
+            .post(EXHIBITION_SIGNED_URLS_PATH)
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .as(new TypeRef<>() {
+            });
+
+        // then
+        assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS);
+    }
+
+    @DisplayName("전시 사진 업로드 url 발급 시 파일 크기가 0 이하이면 400(VALIDATION_FAILED)을 반환한다")
+    @ParameterizedTest
+    @ValueSource(longs = {0L, -1L})
+    void issueExhibitionSignedUrlsWithNonPositiveSize(long nonPositiveSize) {
+        // given
+        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
+            new UploadFileRequest("abc.webp", nonPositiveSize)
+        ));
+
+        // when
+        ApiResponse<Void> result = postExhibitionSignedUrlsExpectingBadRequest(request);
+
+        // then
+        assertThat(result.code()).isEqualTo(ResponseCode.VALIDATION_FAILED);
+    }
+
+    @DisplayName("전시 사진 업로드 url 발급 시 파일명이 null이면 400(VALIDATION_FAILED)을 반환한다")
+    @Test
+    void issueExhibitionSignedUrlsWithNullFileName() {
+        // given
+        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
+            new UploadFileRequest(null, 1024L)
         ));
 
         // when

--- a/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
@@ -14,6 +14,8 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.http.HttpStatus;
@@ -192,6 +194,32 @@ class UploadAcceptanceTest extends AcceptanceTest {
     void issueExhibitionSignedUrlsWithNullFileNames() {
         // given
         IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(null);
+
+        // when
+        ApiResponse<Void> result = RestAssuredMockMvc.given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(request)
+            .when()
+            .post("/exhibitions/upload/signed-urls")
+            .then()
+            .statusCode(HttpStatus.BAD_REQUEST.value())
+            .extract()
+            .body()
+            .as(new TypeRef<>() {
+            });
+
+        // then
+        assertThat(result.code()).isEqualTo(ResponseCode.VALIDATION_FAILED);
+    }
+
+    @DisplayName("전시 사진 업로드 url 발급 시 파일명 형식이 올바르지 않으면 400을 반환한다")
+    @ParameterizedTest
+    @ValueSource(strings = {"../../../etc/passwd", "a/b.png", "a\\b.png", "noext", "x.gif"})
+    void issueExhibitionSignedUrlsWithInvalidFileName(String invalidFileName) {
+        // given
+        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(invalidFileName));
 
         // when
         ApiResponse<Void> result = RestAssuredMockMvc.given()

--- a/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
@@ -30,7 +30,7 @@ import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.HostRepository;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.AwsS3Cloud;
-import com.forgather.domain.upload.domain.UploadFile;
+import com.forgather.domain.upload.domain.UploadFileMetadata;
 import com.forgather.domain.upload.dto.IssuePreSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssuePreSignedUrlRequest.UploadFileRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
@@ -226,7 +226,7 @@ class UploadAcceptanceTest extends AcceptanceTest {
     @Test
     void issueExhibitionSignedUrlsWithOversizeFile() {
         // given
-        long oversize = UploadFile.MAX_FILE_SIZE_BYTES + 1;
+        long oversize = UploadFileMetadata.MAX_FILE_SIZE_BYTES + 1;
         IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
             new UploadFileRequest("abc.webp", oversize)
         ));
@@ -243,7 +243,7 @@ class UploadAcceptanceTest extends AcceptanceTest {
     void issueExhibitionSignedUrlsWithExactlyMaxSizeFile() {
         // given
         IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
-            new UploadFileRequest("abc.webp", UploadFile.MAX_FILE_SIZE_BYTES)
+            new UploadFileRequest("abc.webp", UploadFileMetadata.MAX_FILE_SIZE_BYTES)
         ));
         when(awsS3Cloud.getRootDirectory()).thenReturn("photogather/v2");
         when(awsS3Cloud.issueSignedUrl(anyString(), anyString(), anyLong())).thenAnswer(invocation -> {

--- a/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
@@ -11,11 +11,14 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -42,6 +45,8 @@ import io.restassured.module.mockmvc.RestAssuredMockMvc;
 
 @AutoConfigureMockMvc
 class UploadAcceptanceTest extends AcceptanceTest {
+
+    private static final String EXHIBITION_SIGNED_URLS_PATH = "/exhibitions/upload/signed-urls";
 
     @Autowired
     private MockMvc mockMvc;
@@ -115,8 +120,8 @@ class UploadAcceptanceTest extends AcceptanceTest {
     void issueExhibitionSignedUrls() {
         // given
         IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
-            new UploadFileRequest("abc.jpg", 1024L),
-            new UploadFileRequest("def.jpg", 2048L)
+            new UploadFileRequest("abc.webp", 1024L),
+            new UploadFileRequest("def.webp", 2048L)
         ));
         when(awsS3Cloud.getRootDirectory()).thenReturn("photogather/v2");
         when(awsS3Cloud.issueSignedUrl(anyString(), anyString(), anyLong())).thenAnswer(invocation -> {
@@ -131,7 +136,7 @@ class UploadAcceptanceTest extends AcceptanceTest {
             .accept(ContentType.JSON)
             .body(request)
             .when()
-            .post("/exhibitions/upload/signed-urls")
+            .post(EXHIBITION_SIGNED_URLS_PATH)
             .then()
             .statusCode(200)
             .extract()
@@ -145,10 +150,10 @@ class UploadAcceptanceTest extends AcceptanceTest {
         assertAll(
             () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
             () -> assertThat(result.message()).isNull(),
-            () -> assertThat(signedUrls.get("abc.jpg"))
-                .isEqualTo(expectedPrefix + "abc.jpg-test-suffix"),
-            () -> assertThat(signedUrls.get("def.jpg"))
-                .isEqualTo(expectedPrefix + "def.jpg-test-suffix")
+            () -> assertThat(signedUrls.get("abc.webp"))
+                .isEqualTo(expectedPrefix + "abc.webp-test-suffix"),
+            () -> assertThat(signedUrls.get("def.webp"))
+                .isEqualTo(expectedPrefix + "def.webp-test-suffix")
         );
     }
 
@@ -157,7 +162,7 @@ class UploadAcceptanceTest extends AcceptanceTest {
     void issueExhibitionSignedUrlsRequiresAuth() {
         // given
         IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
-            new UploadFileRequest("abc.jpg", 1024L)
+            new UploadFileRequest("abc.webp", 1024L)
         ));
 
         // when, then
@@ -166,64 +171,25 @@ class UploadAcceptanceTest extends AcceptanceTest {
             .accept(ContentType.JSON)
             .body(request)
             .when()
-            .post("/exhibitions/upload/signed-urls")
+            .post(EXHIBITION_SIGNED_URLS_PATH)
             .then()
             .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 
-    @DisplayName("전시 사진 서명된 url 발급 시 업로드 파일 이름 목록이 비어있으면 400을 반환한다")
-    @Test
-    void issueExhibitionSignedUrlsWithEmptyFileNames() {
-        // given
-        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of());
-
-        // when
-        ApiResponse<Void> result = RestAssuredMockMvc.given()
-            .header("Authorization", "Bearer " + token)
-            .contentType(ContentType.JSON)
-            .accept(ContentType.JSON)
-            .body(request)
-            .when()
-            .post("/exhibitions/upload/signed-urls")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value())
-            .extract()
-            .body()
-            .as(new TypeRef<>() {
-            });
-
-        // then
-        assertThat(result.code()).isEqualTo(ResponseCode.VALIDATION_FAILED);
-    }
-
-    @DisplayName("전시 사진 서명된 url 발급 시 업로드 파일 이름 목록이 null이면 400을 반환한다")
-    @Test
-    void issueExhibitionSignedUrlsWithNullFileNames() {
-        // given
-        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(null);
-
-        // when
-        ApiResponse<Void> result = RestAssuredMockMvc.given()
-            .header("Authorization", "Bearer " + token)
-            .contentType(ContentType.JSON)
-            .accept(ContentType.JSON)
-            .body(request)
-            .when()
-            .post("/exhibitions/upload/signed-urls")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value())
-            .extract()
-            .body()
-            .as(new TypeRef<>() {
-            });
-
-        // then
-        assertThat(result.code()).isEqualTo(ResponseCode.VALIDATION_FAILED);
-    }
-
-    @DisplayName("전시 사진 업로드 url 발급 시 파일명 형식이 올바르지 않으면 400을 반환한다")
+    @DisplayName("전시 사진 서명된 url 발급 시 업로드 파일 목록이 비어있거나 null이면 400(VALIDATION_FAILED)을 반환한다")
     @ParameterizedTest
-    @ValueSource(strings = {"../../../etc/passwd", "a/b.png", "a\\b.png", "noext", "x.gif"})
+    @MethodSource("emptyOrNullFileRequests")
+    void issueExhibitionSignedUrlsWithEmptyOrNullFileNames(IssuePreSignedUrlRequest request) {
+        // when
+        ApiResponse<Void> result = postExhibitionSignedUrlsExpectingBadRequest(request);
+
+        // then
+        assertThat(result.code()).isEqualTo(ResponseCode.VALIDATION_FAILED);
+    }
+
+    @DisplayName("전시 사진 업로드 url 발급 시 파일명 형식이 올바르지 않으면 400(VALIDATION_FAILED)을 반환한다")
+    @ParameterizedTest
+    @ValueSource(strings = {"../../../etc/passwd", "a/b.webp", "a\\b.webp", "noext", "abc.WEBP"})
     void issueExhibitionSignedUrlsWithInvalidFileName(String invalidFileName) {
         // given
         IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
@@ -231,22 +197,26 @@ class UploadAcceptanceTest extends AcceptanceTest {
         ));
 
         // when
-        ApiResponse<Void> result = RestAssuredMockMvc.given()
-            .header("Authorization", "Bearer " + token)
-            .contentType(ContentType.JSON)
-            .accept(ContentType.JSON)
-            .body(request)
-            .when()
-            .post("/exhibitions/upload/signed-urls")
-            .then()
-            .statusCode(HttpStatus.BAD_REQUEST.value())
-            .extract()
-            .body()
-            .as(new TypeRef<>() {
-            });
+        ApiResponse<Void> result = postExhibitionSignedUrlsExpectingBadRequest(request);
 
         // then
         assertThat(result.code()).isEqualTo(ResponseCode.VALIDATION_FAILED);
+    }
+
+    @DisplayName("전시 사진 업로드 url 발급 시 형식은 맞지만 지원하지 않는 확장자면 BAD_REQUEST를 반환한다")
+    @ParameterizedTest
+    @ValueSource(strings = {"photo.png", "photo.jpg", "x.gif", "icon.svg", "document.pdf"})
+    void issueExhibitionSignedUrlsWithUnsupportedExtension(String unsupportedFileName) {
+        // given
+        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
+            new UploadFileRequest(unsupportedFileName, 1024L)
+        ));
+
+        // when
+        ApiResponse<Void> result = postExhibitionSignedUrlsExpectingBadRequest(request);
+
+        // then
+        assertThat(result.code()).isEqualTo(ResponseCode.BAD_REQUEST);
     }
 
     @DisplayName("전시 사진 업로드 url 발급 시 파일 크기가 20MB를 초과하면 400을 반환한다")
@@ -255,25 +225,36 @@ class UploadAcceptanceTest extends AcceptanceTest {
         // given
         long oversize = 20L * 1024 * 1024 + 1;
         IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
-            new UploadFileRequest("abc.jpg", oversize)
+            new UploadFileRequest("abc.webp", oversize)
         ));
 
         // when
-        ApiResponse<Void> result = RestAssuredMockMvc.given()
+        ApiResponse<Void> result = postExhibitionSignedUrlsExpectingBadRequest(request);
+
+        // then
+        assertThat(result.code()).isEqualTo(ResponseCode.VALIDATION_FAILED);
+    }
+
+    private static Stream<Named<IssuePreSignedUrlRequest>> emptyOrNullFileRequests() {
+        return Stream.of(
+            Named.of("빈 목록", new IssuePreSignedUrlRequest(List.of())),
+            Named.of("null", new IssuePreSignedUrlRequest(null))
+        );
+    }
+
+    private ApiResponse<Void> postExhibitionSignedUrlsExpectingBadRequest(IssuePreSignedUrlRequest request) {
+        return RestAssuredMockMvc.given()
             .header("Authorization", "Bearer " + token)
             .contentType(ContentType.JSON)
             .accept(ContentType.JSON)
             .body(request)
             .when()
-            .post("/exhibitions/upload/signed-urls")
+            .post(EXHIBITION_SIGNED_URLS_PATH)
             .then()
             .statusCode(HttpStatus.BAD_REQUEST.value())
             .extract()
             .body()
             .as(new TypeRef<>() {
             });
-
-        // then
-        assertThat(result.code()).isEqualTo(ResponseCode.VALIDATION_FAILED);
     }
 }

--- a/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -292,6 +293,22 @@ class UploadAcceptanceTest extends AcceptanceTest {
         // given
         IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(List.of(
             new UploadFileRequest(null, 1024L)
+        ));
+
+        // when
+        ApiResponse<Void> result = postExhibitionSignedUrlsExpectingBadRequest(request);
+
+        // then
+        assertThat(result.code()).isEqualTo(ResponseCode.VALIDATION_FAILED);
+    }
+
+    @DisplayName("전시 사진 업로드 url 발급 시 업로드 파일 목록에 null이 포함되면 400(VALIDATION_FAILED)을 반환한다")
+    @Test
+    void issueExhibitionSignedUrlsWithNullFileElement() {
+        // given
+        IssuePreSignedUrlRequest request = new IssuePreSignedUrlRequest(Arrays.asList(
+            new UploadFileRequest("abc.webp", 1024L),
+            null
         ));
 
         // when

--- a/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/UploadAcceptanceTest.java
@@ -1,6 +1,8 @@
 package com.forgather.acceptance;
 
+import static com.forgather.domain.upload.domain.UploadCategory.EXHIBITION;
 import static com.forgather.domain.upload.domain.UploadCategory.GUESTBOOK;
+import static com.forgather.fixture.HostFixture.createHost;
 import static com.forgather.fixture.SpaceFixture.createSpace;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -15,14 +17,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.forgather.domain.space.model.Space;
+import com.forgather.domain.space.repository.HostRepository;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.AwsS3Cloud;
 import com.forgather.domain.upload.dto.IssueSignedUrlRequest;
 import com.forgather.domain.upload.dto.IssueSignedUrlResponse;
+import com.forgather.global.auth.model.Host;
+import com.forgather.global.auth.util.JwtTokenProvider;
 import com.forgather.global.response.ApiResponse;
 import com.forgather.global.response.ResponseCode;
 
@@ -39,15 +45,25 @@ class UploadAcceptanceTest extends AcceptanceTest {
     @Autowired
     private SpaceRepository spaceRepository;
 
+    @Autowired
+    private HostRepository hostRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
     @MockitoBean
     private AwsS3Cloud awsS3Cloud;
 
     private Space space;
+    private Host host;
+    private String token;
 
     @BeforeEach
     void setUp() {
         space = createSpace();
         spaceRepository.save(space);
+        host = hostRepository.save(createHost());
+        token = jwtTokenProvider.generateAccessToken(host.getId());
         RestAssuredMockMvc.mockMvc(mockMvc);
     }
 
@@ -88,5 +104,61 @@ class UploadAcceptanceTest extends AcceptanceTest {
             () -> assertThat(signedUrls.get("hij.png"))
                 .isEqualTo("test-prefix-photogather/v2/spaces/1234567890/guestbook/hij.png-test-suffix")
         );
+    }
+
+    @DisplayName("전시 사진 서명된 url 발급")
+    @Test
+    void issueExhibitionSignedUrls() {
+        // given
+        IssueSignedUrlRequest request = new IssueSignedUrlRequest(EXHIBITION, List.of("abc.jpg", "def.jpg"));
+        when(awsS3Cloud.getRootDirectory()).thenReturn("photogather/v2");
+        when(awsS3Cloud.issueSignedUrl(anyString())).thenAnswer(invocation -> {
+            String path = invocation.getArgument(0);
+            return "test-prefix-" + path + "-test-suffix";
+        });
+
+        // when
+        ApiResponse<IssueSignedUrlResponse> result = RestAssuredMockMvc.given()
+            .header("Authorization", "Bearer " + token)
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(request)
+            .when()
+            .post("/exhibitions/upload/signed-urls")
+            .then()
+            .statusCode(200)
+            .extract()
+            .body()
+            .as(new TypeRef<>() {
+            });
+        Map<String, String> signedUrls = result.data().signedUrls();
+
+        // then
+        String expectedPrefix = "test-prefix-photogather/v2/exhibitions/host-%d/".formatted(host.getId());
+        assertAll(
+            () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
+            () -> assertThat(result.message()).isNull(),
+            () -> assertThat(signedUrls.get("abc.jpg"))
+                .isEqualTo(expectedPrefix + "abc.jpg-test-suffix"),
+            () -> assertThat(signedUrls.get("def.jpg"))
+                .isEqualTo(expectedPrefix + "def.jpg-test-suffix")
+        );
+    }
+
+    @DisplayName("전시 사진 서명된 url 발급은 인증 없이 호출하면 401을 반환한다")
+    @Test
+    void issueExhibitionSignedUrlsRequiresAuth() {
+        // given
+        IssueSignedUrlRequest request = new IssueSignedUrlRequest(EXHIBITION, List.of("abc.jpg"));
+
+        // when, then
+        RestAssuredMockMvc.given()
+            .contentType(ContentType.JSON)
+            .accept(ContentType.JSON)
+            .body(request)
+            .when()
+            .post("/exhibitions/upload/signed-urls")
+            .then()
+            .statusCode(HttpStatus.UNAUTHORIZED.value());
     }
 }

--- a/src/test/java/com/forgather/domain/exhibition/service/ExhibitionServiceTest.java
+++ b/src/test/java/com/forgather/domain/exhibition/service/ExhibitionServiceTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.forgather.container.TestOnContainer;
+import com.forgather.domain.exhibition.dto.CreateExhibitionPhotoRequest;
 import com.forgather.domain.exhibition.dto.CreateExhibitionRequest;
 import com.forgather.domain.exhibition.dto.ExhibitionResponse;
 import com.forgather.domain.exhibition.dto.LocationRequest;
@@ -47,8 +48,7 @@ class ExhibitionServiceTest extends TestOnContainer {
         // given
         Host host = hostRepository.save(HostFixture.createHost());
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/abc.webp",
-            1024L,
+            new CreateExhibitionPhotoRequest("abc.webp", 1024L),
             "봄 전시",
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),
@@ -68,7 +68,8 @@ class ExhibitionServiceTest extends TestOnContainer {
         assertAll(
             () -> assertThat(response.id()).isNotNull(),
             () -> assertThat(response.title()).isEqualTo("봄 전시"),
-            () -> assertThat(response.representativeImagePath()).isEqualTo("exhibitions/abc.webp"),
+            () -> assertThat(response.representativeImagePath())
+                .isEqualTo("ROOT_DIRECTORY_PLACEHOLDER/exhibitions/host-%d/abc.webp".formatted(host.getId())),
             () -> assertThat(response.location().locationType()).isEqualTo(LocationType.ONLINE),
             () -> assertThat(response.location().url()).isEqualTo("https://forgather.app"),
             () -> assertThat(response.operatingHours()).hasSize(2),
@@ -82,8 +83,7 @@ class ExhibitionServiceTest extends TestOnContainer {
         // given
         Host host = hostRepository.save(HostFixture.createHost());
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/offline.webp",
-            2048L,
+            new CreateExhibitionPhotoRequest("offline.webp", 2048L),
             "여름 전시",
             LocalDate.of(2026, 7, 1),
             LocalDate.of(2026, 7, 31),
@@ -112,8 +112,7 @@ class ExhibitionServiceTest extends TestOnContainer {
         // given
         Host host = hostRepository.save(HostFixture.createHost());
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/dup.webp",
-            1024L,
+            new CreateExhibitionPhotoRequest("dup.webp", 1024L),
             "중복 요일 전시",
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),
@@ -138,8 +137,7 @@ class ExhibitionServiceTest extends TestOnContainer {
         // given
         Host host = hostRepository.save(HostFixture.createHost());
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/partial.webp",
-            1024L,
+            new CreateExhibitionPhotoRequest("partial.webp", 1024L),
             "월수금 전시",
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),
@@ -166,8 +164,7 @@ class ExhibitionServiceTest extends TestOnContainer {
         // given
         Host host = hostRepository.save(HostFixture.createHost());
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/sort.webp",
-            1024L,
+            new CreateExhibitionPhotoRequest("sort.webp", 1024L),
             "정렬 검증 전시",
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),
@@ -196,8 +193,7 @@ class ExhibitionServiceTest extends TestOnContainer {
         // given
         Host host = hostRepository.save(HostFixture.createHost());
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/multi-range.webp",
-            1024L,
+            new CreateExhibitionPhotoRequest("multi-range.webp", 1024L),
             "다중 구간 전시",
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),
@@ -222,8 +218,7 @@ class ExhibitionServiceTest extends TestOnContainer {
         // given
         Host host = hostRepository.save(HostFixture.createHost());
         CreateExhibitionRequest request = new CreateExhibitionRequest(
-            "exhibitions/empty.webp",
-            1024L,
+            new CreateExhibitionPhotoRequest("empty.webp", 1024L),
             "빈 운영시간 전시",
             LocalDate.of(2026, 6, 1),
             LocalDate.of(2026, 6, 30),

--- a/src/test/java/com/forgather/domain/exhibition/service/ExhibitionServiceTest.java
+++ b/src/test/java/com/forgather/domain/exhibition/service/ExhibitionServiceTest.java
@@ -68,7 +68,7 @@ class ExhibitionServiceTest extends TestOnContainer {
         assertAll(
             () -> assertThat(response.id()).isNotNull(),
             () -> assertThat(response.title()).isEqualTo("봄 전시"),
-            () -> assertThat(response.representativeImagePath())
+            () -> assertThat(response.photoPath())
                 .isEqualTo("ROOT_DIRECTORY_PLACEHOLDER/exhibitions/abc.webp"),
             () -> assertThat(response.location().locationType()).isEqualTo(LocationType.ONLINE),
             () -> assertThat(response.location().url()).isEqualTo("https://forgather.app"),
@@ -103,6 +103,32 @@ class ExhibitionServiceTest extends TestOnContainer {
             () -> assertThat(response.location().baseAddress()).isEqualTo("서울특별시 송파구"),
             () -> assertThat(response.location().detailAddress()).isEqualTo("루터회관"),
             () -> assertThat(response.operatingHours()).isNull()
+        );
+    }
+
+    @DisplayName("전시 사진 없이 생성하면 응답의 대표 이미지 경로는 null이다.")
+    @Test
+    void createWithoutPhoto() {
+        // given
+        Host host = hostRepository.save(HostFixture.createHost());
+        CreateExhibitionRequest request = new CreateExhibitionRequest(
+            null,
+            "사진 없는 전시",
+            LocalDate.of(2026, 6, 1),
+            LocalDate.of(2026, 6, 30),
+            "사진 없이 생성한 전시입니다.",
+            null,
+            null,
+            new LocationRequest(LocationType.ONLINE, "https://forgather.app", null, null)
+        );
+
+        // when
+        ExhibitionResponse response = exhibitionService.create(host, request);
+
+        // then
+        assertAll(
+            () -> assertThat(response.id()).isNotNull(),
+            () -> assertThat(response.photoPath()).isNull()
         );
     }
 

--- a/src/test/java/com/forgather/domain/exhibition/service/ExhibitionServiceTest.java
+++ b/src/test/java/com/forgather/domain/exhibition/service/ExhibitionServiceTest.java
@@ -69,7 +69,7 @@ class ExhibitionServiceTest extends TestOnContainer {
             () -> assertThat(response.id()).isNotNull(),
             () -> assertThat(response.title()).isEqualTo("봄 전시"),
             () -> assertThat(response.representativeImagePath())
-                .isEqualTo("ROOT_DIRECTORY_PLACEHOLDER/exhibitions/host-%d/abc.webp".formatted(host.getId())),
+                .isEqualTo("ROOT_DIRECTORY_PLACEHOLDER/exhibitions/abc.webp"),
             () -> assertThat(response.location().locationType()).isEqualTo(LocationType.ONLINE),
             () -> assertThat(response.location().url()).isEqualTo("https://forgather.app"),
             () -> assertThat(response.operatingHours()).hasSize(2),

--- a/src/test/java/com/forgather/domain/upload/domain/ImageContentTypeTest.java
+++ b/src/test/java/com/forgather/domain/upload/domain/ImageContentTypeTest.java
@@ -1,0 +1,83 @@
+package com.forgather.domain.upload.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.forgather.global.exception.BaseException;
+
+class ImageContentTypeTest {
+
+    @DisplayName("지원하는 확장자의 파일명은 대응하는 Content-Type을 반환한다")
+    @ParameterizedTest
+    @CsvSource({
+        "photo.webp, image/webp"
+    })
+    void resolveByFileName(String fileName, String expectedMimeType) {
+        assertThat(ImageContentType.resolveByFileName(fileName)).isEqualTo(expectedMimeType);
+    }
+
+    @DisplayName("확장자 대소문자를 구분하지 않고 Content-Type을 반환한다")
+    @ParameterizedTest
+    @CsvSource({
+        "photo.WEBP, image/webp",
+        "photo.WebP, image/webp"
+    })
+    void resolveByFileNameIgnoringCase(String fileName, String expectedMimeType) {
+        assertThat(ImageContentType.resolveByFileName(fileName)).isEqualTo(expectedMimeType);
+    }
+
+    @DisplayName("점이 여러 개인 파일명은 마지막 확장자를 기준으로 Content-Type을 반환한다")
+    @ParameterizedTest
+    @CsvSource({
+        "archive.tar.webp, image/webp",
+        "my.photo.webp, image/webp"
+    })
+    void resolveByFileNameWithMultipleDots(String fileName, String expectedMimeType) {
+        assertThat(ImageContentType.resolveByFileName(fileName)).isEqualTo(expectedMimeType);
+    }
+
+    @DisplayName("지원하지 않는 확장자의 파일명은 예외를 던진다")
+    @ParameterizedTest
+    @ValueSource(strings = {"photo.png", "photo.jpg", "photo.jpeg", "photo.gif", "icon.svg", "evil.webp.exe"})
+    void resolveByFileNameWithUnsupportedExtension(String fileName) {
+        assertThatThrownBy(() -> ImageContentType.resolveByFileName(fileName))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("지원하지 않는 이미지 확장자");
+    }
+
+    @DisplayName("확장자가 없는 파일명은 예외를 던진다")
+    @ParameterizedTest
+    @ValueSource(strings = {"noext", "filename."})
+    void resolveByFileNameWithoutExtension(String fileName) {
+        assertThatThrownBy(() -> ImageContentType.resolveByFileName(fileName))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("지원하지 않는 이미지 확장자");
+    }
+
+    @DisplayName("지원하는 확장자의 파일명이면 true를 반환한다")
+    @ParameterizedTest
+    @ValueSource(strings = {"photo.webp", "photo.WEBP", "archive.tar.webp"})
+    void isSupportedFileName(String fileName) {
+        assertThat(ImageContentType.isSupportedFileName(fileName)).isTrue();
+    }
+
+    @DisplayName("지원하지 않거나 확장자가 없는 파일명이면 false를 반환한다")
+    @ParameterizedTest
+    @ValueSource(strings = {"photo.png", "photo.jpg", "photo.gif", "icon.svg", "evil.webp.exe", "noext"})
+    void isSupportedFileNameReturnsFalse(String fileName) {
+        assertThat(ImageContentType.isSupportedFileName(fileName)).isFalse();
+    }
+
+    @DisplayName("파일명이 null이거나 비어있으면 지원하지 않는 것으로 판단한다")
+    @ParameterizedTest
+    @NullAndEmptySource
+    void isSupportedFileNameWithNullOrEmpty(String fileName) {
+        assertThat(ImageContentType.isSupportedFileName(fileName)).isFalse();
+    }
+}

--- a/src/test/java/com/forgather/domain/upload/domain/SignedUrlIssuerTest.java
+++ b/src/test/java/com/forgather/domain/upload/domain/SignedUrlIssuerTest.java
@@ -21,9 +21,9 @@ class SignedUrlIssuerTest {
 
     private final SignedUrlIssuer signedUrlIssuer = new SignedUrlIssuer(new FakeContentStorage());
 
-    private List<UploadFile> uploadFiles(String... fileNames) {
+    private List<UploadFileMetadata> uploadFiles(String... fileNames) {
         return Arrays.stream(fileNames)
-            .map(fileName -> new UploadFile(fileName, 1024L))
+            .map(fileName -> new UploadFileMetadata(fileName, 1024L))
             .toList();
     }
 
@@ -31,7 +31,7 @@ class SignedUrlIssuerTest {
     @Test
     void issueForSpace() {
         // given
-        List<UploadFile> files = uploadFiles("abc.webp", "def.webp", "hij.webp");
+        List<UploadFileMetadata> files = uploadFiles("abc.webp", "def.webp", "hij.webp");
 
         // when
         Map<String, String> result = signedUrlIssuer.issueForSpace(files, "1234567890", PRODUCT);
@@ -51,8 +51,8 @@ class SignedUrlIssuerTest {
     @Test
     void throwExceptionWhenExceedMaxCount() {
         // given
-        List<UploadFile> files = IntStream.range(0, 101)
-            .mapToObj(number -> new UploadFile(number + ".webp", 1024L))
+        List<UploadFileMetadata> files = IntStream.range(0, 101)
+            .mapToObj(number -> new UploadFileMetadata(number + ".webp", 1024L))
             .toList();
 
         // when, then
@@ -65,8 +65,8 @@ class SignedUrlIssuerTest {
     @Test
     void notThrowExceptionWhenNotExceedMaxCount() {
         // given
-        List<UploadFile> files = IntStream.range(0, 100)
-            .mapToObj(number -> new UploadFile(number + ".webp", 1024L))
+        List<UploadFileMetadata> files = IntStream.range(0, 100)
+            .mapToObj(number -> new UploadFileMetadata(number + ".webp", 1024L))
             .toList();
 
         // when, then
@@ -87,7 +87,7 @@ class SignedUrlIssuerTest {
     @Test
     void issueForExhibition() {
         // given
-        List<UploadFile> files = uploadFiles("abc.webp", "def.webp");
+        List<UploadFileMetadata> files = uploadFiles("abc.webp", "def.webp");
 
         // when
         Map<String, String> result = signedUrlIssuer.issueForExhibition(files);
@@ -105,8 +105,8 @@ class SignedUrlIssuerTest {
     @Test
     void throwExceptionWhenExhibitionExceedMaxCount() {
         // given
-        List<UploadFile> files = IntStream.range(0, 101)
-            .mapToObj(number -> new UploadFile(number + ".webp", 1024L))
+        List<UploadFileMetadata> files = IntStream.range(0, 101)
+            .mapToObj(number -> new UploadFileMetadata(number + ".webp", 1024L))
             .toList();
 
         // when, then

--- a/src/test/java/com/forgather/domain/upload/domain/SignedUrlIssuerTest.java
+++ b/src/test/java/com/forgather/domain/upload/domain/SignedUrlIssuerTest.java
@@ -88,17 +88,16 @@ class SignedUrlIssuerTest {
     void issueForExhibition() {
         // given
         List<UploadFile> files = uploadFiles("abc.webp", "def.webp");
-        long hostId = 1L;
 
         // when
-        Map<String, String> result = signedUrlIssuer.issueForExhibition(files, hostId);
+        Map<String, String> result = signedUrlIssuer.issueForExhibition(files);
 
         // then
         assertAll(
             () -> assertThat(result.get("abc.webp"))
-                .isEqualTo("test-prefix-photogather/v2/exhibitions/host-1/abc.webp-test-suffix"),
+                .isEqualTo("test-prefix-photogather/v2/exhibitions/abc.webp-test-suffix"),
             () -> assertThat(result.get("def.webp"))
-                .isEqualTo("test-prefix-photogather/v2/exhibitions/host-1/def.webp-test-suffix")
+                .isEqualTo("test-prefix-photogather/v2/exhibitions/def.webp-test-suffix")
         );
     }
 
@@ -111,7 +110,7 @@ class SignedUrlIssuerTest {
             .toList();
 
         // when, then
-        assertThatThrownBy(() -> signedUrlIssuer.issueForExhibition(files, 1L))
+        assertThatThrownBy(() -> signedUrlIssuer.issueForExhibition(files))
             .isInstanceOf(BaseException.class)
             .hasMessageContaining("한번에 발급 가능한 업로드 url 개수");
     }
@@ -120,7 +119,7 @@ class SignedUrlIssuerTest {
     @Test
     void throwExceptionWhenExhibitionFilesEmpty() {
         // when, then
-        assertThatThrownBy(() -> signedUrlIssuer.issueForExhibition(List.of(), 1L))
+        assertThatThrownBy(() -> signedUrlIssuer.issueForExhibition(List.of()))
             .isInstanceOf(BaseException.class)
             .hasMessageContaining("업로드 파일명 목록은 null이거나 비어있을 수 없습니다");
     }

--- a/src/test/java/com/forgather/domain/upload/domain/SignedUrlIssuerTest.java
+++ b/src/test/java/com/forgather/domain/upload/domain/SignedUrlIssuerTest.java
@@ -1,12 +1,12 @@
 package com.forgather.domain.upload.domain;
 
-import static com.forgather.domain.upload.domain.UploadCategory.EXHIBITION;
 import static com.forgather.domain.upload.domain.UploadCategory.PRODUCT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -19,48 +19,22 @@ import com.forgather.global.exception.BaseException;
 
 class SignedUrlIssuerTest {
 
-    @DisplayName("한 번에 발급 가능한 url 개수를 초과하면 예외를 던진다")
-    @Test
-    void throwExceptionWhenExceedMaxCount() {
-        // given
-        SignedUrlIssuer signedUrlIssuer = new SignedUrlIssuer(new FakeContentStorage());
-        List<String> fileNames = IntStream.range(0, 101)
-            .mapToObj(number -> number + ".jpg")
-            .toList();
+    private final SignedUrlIssuer signedUrlIssuer = new SignedUrlIssuer(new FakeContentStorage());
 
-        // when, then
-        assertThatThrownBy(() -> signedUrlIssuer.issueSignedUrls(fileNames, "1234567890", PRODUCT))
-            .isInstanceOf(BaseException.class)
-            .hasMessageContaining("한번에 발급 가능한 업로드 url 개수");
+    private List<UploadFile> uploadFiles(String... fileNames) {
+        return Arrays.stream(fileNames)
+            .map(fileName -> new UploadFile(fileName, 1024L))
+            .toList();
     }
 
-    @DisplayName("한 번에 발급 가능한 url 개수를 초과하지 않으면 예외를 던지지 않는다")
+    @DisplayName("스페이스 사진의 서명된 url을 발급한다")
     @Test
-    void notThrowExceptionWhenNotExceedMaxCount() {
+    void issueForSpace() {
         // given
-        SignedUrlIssuer signedUrlIssuer = new SignedUrlIssuer(new FakeContentStorage());
-        List<String> fileNames = IntStream.range(0, 100)
-            .mapToObj(number -> number + ".jpg")
-            .toList();
+        List<UploadFile> files = uploadFiles("abc.jpg", "def.jpg", "hij.png");
 
         // when
-        assertThatCode(() -> signedUrlIssuer.issueSignedUrls(fileNames, "1234567890", PRODUCT))
-            .doesNotThrowAnyException();
-    }
-
-    @DisplayName("서명된 url을 발급한다")
-    @Test
-    void issueSignedUrls() {
-        // given
-        SignedUrlIssuer signedUrlIssuer = new SignedUrlIssuer(new FakeContentStorage());
-        List<String> fileNames = List.of("abc.jpg", "def.jpg", "hij.png");
-
-        // when
-        Map<String, String> result = signedUrlIssuer.issueSignedUrls(
-            fileNames,
-            "1234567890",
-            PRODUCT
-        );
+        Map<String, String> result = signedUrlIssuer.issueForSpace(files, "1234567890", PRODUCT);
 
         // then
         assertAll(
@@ -73,16 +47,51 @@ class SignedUrlIssuerTest {
         );
     }
 
+    @DisplayName("한 번에 발급 가능한 url 개수를 초과하면 예외를 던진다")
+    @Test
+    void throwExceptionWhenExceedMaxCount() {
+        // given
+        List<UploadFile> files = IntStream.range(0, 101)
+            .mapToObj(number -> new UploadFile(number + ".jpg", 1024L))
+            .toList();
+
+        // when, then
+        assertThatThrownBy(() -> signedUrlIssuer.issueForSpace(files, "1234567890", PRODUCT))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("한번에 발급 가능한 업로드 url 개수");
+    }
+
+    @DisplayName("한 번에 발급 가능한 url 개수를 초과하지 않으면 예외를 던지지 않는다")
+    @Test
+    void notThrowExceptionWhenNotExceedMaxCount() {
+        // given
+        List<UploadFile> files = IntStream.range(0, 100)
+            .mapToObj(number -> new UploadFile(number + ".jpg", 1024L))
+            .toList();
+
+        // when, then
+        assertThatCode(() -> signedUrlIssuer.issueForSpace(files, "1234567890", PRODUCT))
+            .doesNotThrowAnyException();
+    }
+
+    @DisplayName("스페이스 사진 발급 시 파일 목록이 비어있으면 예외를 던진다")
+    @Test
+    void throwExceptionWhenSpaceFilesEmpty() {
+        // when, then
+        assertThatThrownBy(() -> signedUrlIssuer.issueForSpace(List.of(), "1234567890", PRODUCT))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("업로드 파일명 목록은 null이거나 비어있을 수 없습니다");
+    }
+
     @DisplayName("전시 사진의 서명된 url을 발급한다")
     @Test
-    void issueExhibitionSignedUrls() {
+    void issueForExhibition() {
         // given
-        SignedUrlIssuer signedUrlIssuer = new SignedUrlIssuer(new FakeContentStorage());
-        List<String> fileNames = List.of("abc.jpg", "def.jpg");
+        List<UploadFile> files = uploadFiles("abc.jpg", "def.jpg");
         long hostId = 1L;
 
         // when
-        Map<String, String> result = signedUrlIssuer.issueSignedUrls(fileNames, EXHIBITION, hostId);
+        Map<String, String> result = signedUrlIssuer.issueForExhibition(files, hostId);
 
         // then
         assertAll(
@@ -97,25 +106,21 @@ class SignedUrlIssuerTest {
     @Test
     void throwExceptionWhenExhibitionExceedMaxCount() {
         // given
-        SignedUrlIssuer signedUrlIssuer = new SignedUrlIssuer(new FakeContentStorage());
-        List<String> fileNames = IntStream.range(0, 101)
-            .mapToObj(number -> number + ".jpg")
+        List<UploadFile> files = IntStream.range(0, 101)
+            .mapToObj(number -> new UploadFile(number + ".jpg", 1024L))
             .toList();
 
         // when, then
-        assertThatThrownBy(() -> signedUrlIssuer.issueSignedUrls(fileNames, EXHIBITION, 1L))
+        assertThatThrownBy(() -> signedUrlIssuer.issueForExhibition(files, 1L))
             .isInstanceOf(BaseException.class)
             .hasMessageContaining("한번에 발급 가능한 업로드 url 개수");
     }
 
-    @DisplayName("전시 사진 서명 url 발급 시 파일명 목록이 비어있으면 예외를 던진다")
+    @DisplayName("전시 사진 서명 url 발급 시 파일 목록이 비어있으면 예외를 던진다")
     @Test
-    void throwExceptionWhenExhibitionFileNamesEmpty() {
-        // given
-        SignedUrlIssuer signedUrlIssuer = new SignedUrlIssuer(new FakeContentStorage());
-
+    void throwExceptionWhenExhibitionFilesEmpty() {
         // when, then
-        assertThatThrownBy(() -> signedUrlIssuer.issueSignedUrls(List.of(), EXHIBITION, 1L))
+        assertThatThrownBy(() -> signedUrlIssuer.issueForExhibition(List.of(), 1L))
             .isInstanceOf(BaseException.class)
             .hasMessageContaining("업로드 파일명 목록은 null이거나 비어있을 수 없습니다");
     }

--- a/src/test/java/com/forgather/domain/upload/domain/SignedUrlIssuerTest.java
+++ b/src/test/java/com/forgather/domain/upload/domain/SignedUrlIssuerTest.java
@@ -1,5 +1,6 @@
 package com.forgather.domain.upload.domain;
 
+import static com.forgather.domain.upload.domain.UploadCategory.EXHIBITION;
 import static com.forgather.domain.upload.domain.UploadCategory.PRODUCT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -70,5 +71,52 @@ class SignedUrlIssuerTest {
             () -> assertThat(result.get("hij.png"))
                 .isEqualTo("test-prefix-photogather/v2/spaces/1234567890/product/hij.png-test-suffix")
         );
+    }
+
+    @DisplayName("전시 사진의 서명된 url을 발급한다")
+    @Test
+    void issueExhibitionSignedUrls() {
+        // given
+        SignedUrlIssuer signedUrlIssuer = new SignedUrlIssuer(new FakeContentStorage());
+        List<String> fileNames = List.of("abc.jpg", "def.jpg");
+        long hostId = 1L;
+
+        // when
+        Map<String, String> result = signedUrlIssuer.issueSignedUrls(fileNames, EXHIBITION, hostId);
+
+        // then
+        assertAll(
+            () -> assertThat(result.get("abc.jpg"))
+                .isEqualTo("test-prefix-photogather/v2/exhibitions/host-1/abc.jpg-test-suffix"),
+            () -> assertThat(result.get("def.jpg"))
+                .isEqualTo("test-prefix-photogather/v2/exhibitions/host-1/def.jpg-test-suffix")
+        );
+    }
+
+    @DisplayName("전시 사진 서명 url 발급 시 한 번에 발급 가능한 개수를 초과하면 예외를 던진다")
+    @Test
+    void throwExceptionWhenExhibitionExceedMaxCount() {
+        // given
+        SignedUrlIssuer signedUrlIssuer = new SignedUrlIssuer(new FakeContentStorage());
+        List<String> fileNames = IntStream.range(0, 101)
+            .mapToObj(number -> number + ".jpg")
+            .toList();
+
+        // when, then
+        assertThatThrownBy(() -> signedUrlIssuer.issueSignedUrls(fileNames, EXHIBITION, 1L))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("한번에 발급 가능한 업로드 url 개수");
+    }
+
+    @DisplayName("전시 사진 서명 url 발급 시 파일명 목록이 비어있으면 예외를 던진다")
+    @Test
+    void throwExceptionWhenExhibitionFileNamesEmpty() {
+        // given
+        SignedUrlIssuer signedUrlIssuer = new SignedUrlIssuer(new FakeContentStorage());
+
+        // when, then
+        assertThatThrownBy(() -> signedUrlIssuer.issueSignedUrls(List.of(), EXHIBITION, 1L))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("업로드 파일명 목록은 null이거나 비어있을 수 없습니다");
     }
 }

--- a/src/test/java/com/forgather/domain/upload/domain/SignedUrlIssuerTest.java
+++ b/src/test/java/com/forgather/domain/upload/domain/SignedUrlIssuerTest.java
@@ -31,19 +31,19 @@ class SignedUrlIssuerTest {
     @Test
     void issueForSpace() {
         // given
-        List<UploadFile> files = uploadFiles("abc.jpg", "def.jpg", "hij.png");
+        List<UploadFile> files = uploadFiles("abc.webp", "def.webp", "hij.webp");
 
         // when
         Map<String, String> result = signedUrlIssuer.issueForSpace(files, "1234567890", PRODUCT);
 
         // then
         assertAll(
-            () -> assertThat(result.get("abc.jpg"))
-                .isEqualTo("test-prefix-photogather/v2/spaces/1234567890/product/abc.jpg-test-suffix"),
-            () -> assertThat(result.get("def.jpg"))
-                .isEqualTo("test-prefix-photogather/v2/spaces/1234567890/product/def.jpg-test-suffix"),
-            () -> assertThat(result.get("hij.png"))
-                .isEqualTo("test-prefix-photogather/v2/spaces/1234567890/product/hij.png-test-suffix")
+            () -> assertThat(result.get("abc.webp"))
+                .isEqualTo("test-prefix-photogather/v2/spaces/1234567890/product/abc.webp-test-suffix"),
+            () -> assertThat(result.get("def.webp"))
+                .isEqualTo("test-prefix-photogather/v2/spaces/1234567890/product/def.webp-test-suffix"),
+            () -> assertThat(result.get("hij.webp"))
+                .isEqualTo("test-prefix-photogather/v2/spaces/1234567890/product/hij.webp-test-suffix")
         );
     }
 
@@ -52,7 +52,7 @@ class SignedUrlIssuerTest {
     void throwExceptionWhenExceedMaxCount() {
         // given
         List<UploadFile> files = IntStream.range(0, 101)
-            .mapToObj(number -> new UploadFile(number + ".jpg", 1024L))
+            .mapToObj(number -> new UploadFile(number + ".webp", 1024L))
             .toList();
 
         // when, then
@@ -66,7 +66,7 @@ class SignedUrlIssuerTest {
     void notThrowExceptionWhenNotExceedMaxCount() {
         // given
         List<UploadFile> files = IntStream.range(0, 100)
-            .mapToObj(number -> new UploadFile(number + ".jpg", 1024L))
+            .mapToObj(number -> new UploadFile(number + ".webp", 1024L))
             .toList();
 
         // when, then
@@ -87,7 +87,7 @@ class SignedUrlIssuerTest {
     @Test
     void issueForExhibition() {
         // given
-        List<UploadFile> files = uploadFiles("abc.jpg", "def.jpg");
+        List<UploadFile> files = uploadFiles("abc.webp", "def.webp");
         long hostId = 1L;
 
         // when
@@ -95,10 +95,10 @@ class SignedUrlIssuerTest {
 
         // then
         assertAll(
-            () -> assertThat(result.get("abc.jpg"))
-                .isEqualTo("test-prefix-photogather/v2/exhibitions/host-1/abc.jpg-test-suffix"),
-            () -> assertThat(result.get("def.jpg"))
-                .isEqualTo("test-prefix-photogather/v2/exhibitions/host-1/def.jpg-test-suffix")
+            () -> assertThat(result.get("abc.webp"))
+                .isEqualTo("test-prefix-photogather/v2/exhibitions/host-1/abc.webp-test-suffix"),
+            () -> assertThat(result.get("def.webp"))
+                .isEqualTo("test-prefix-photogather/v2/exhibitions/host-1/def.webp-test-suffix")
         );
     }
 
@@ -107,7 +107,7 @@ class SignedUrlIssuerTest {
     void throwExceptionWhenExhibitionExceedMaxCount() {
         // given
         List<UploadFile> files = IntStream.range(0, 101)
-            .mapToObj(number -> new UploadFile(number + ".jpg", 1024L))
+            .mapToObj(number -> new UploadFile(number + ".webp", 1024L))
             .toList();
 
         // when, then

--- a/src/test/java/com/forgather/domain/upload/domain/UploadFileMetadataTest.java
+++ b/src/test/java/com/forgather/domain/upload/domain/UploadFileMetadataTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import com.forgather.global.exception.BaseException;
 
-class UploadFileTest {
+class UploadFileMetadataTest {
 
     @DisplayName("파일 확장자로부터 Content-Type을 유도한다")
     @ParameterizedTest
@@ -20,25 +20,25 @@ class UploadFileTest {
         "photo.webp, image/webp"
     })
     void contentType(String fileName, String expectedContentType) {
-        UploadFile uploadFile = new UploadFile(fileName, 1024L);
+        UploadFileMetadata uploadFile = new UploadFileMetadata(fileName, 1024L);
 
         assertThat(uploadFile.getContentType()).isEqualTo(expectedContentType);
     }
 
     @DisplayName("파일 크기가 최대 크기(20MB) 이하이면 생성된다")
     @ParameterizedTest
-    @ValueSource(longs = {1L, 1024L, UploadFile.MAX_FILE_SIZE_BYTES})
+    @ValueSource(longs = {1L, 1024L, UploadFileMetadata.MAX_FILE_SIZE_BYTES})
     void createWhenSizeWithinLimit(long size) {
-        assertThatCode(() -> new UploadFile("photo.webp", size))
+        assertThatCode(() -> new UploadFileMetadata("photo.webp", size))
             .doesNotThrowAnyException();
     }
 
     @DisplayName("파일 크기가 최대 크기(20MB)를 초과하면 예외를 던진다")
     @Test
     void throwExceptionWhenSizeExceedsLimit() {
-        long oversize = UploadFile.MAX_FILE_SIZE_BYTES + 1;
+        long oversize = UploadFileMetadata.MAX_FILE_SIZE_BYTES + 1;
 
-        assertThatThrownBy(() -> new UploadFile("photo.webp", oversize))
+        assertThatThrownBy(() -> new UploadFileMetadata("photo.webp", oversize))
             .isInstanceOf(BaseException.class)
             .hasMessageContaining("최대");
     }
@@ -47,7 +47,7 @@ class UploadFileTest {
     @ParameterizedTest
     @ValueSource(longs = {0L, -1L})
     void throwExceptionWhenSizeNotPositive(long size) {
-        assertThatThrownBy(() -> new UploadFile("photo.webp", size))
+        assertThatThrownBy(() -> new UploadFileMetadata("photo.webp", size))
             .isInstanceOf(BaseException.class)
             .hasMessageContaining("0보다 커야");
     }
@@ -56,7 +56,7 @@ class UploadFileTest {
     @ParameterizedTest
     @ValueSource(strings = {"../../../etc/passwd", "a/b.webp", "a\\b.webp", "noext", "x.gif"})
     void throwExceptionWhenInvalidFileName(String invalidFileName) {
-        assertThatThrownBy(() -> new UploadFile(invalidFileName, 1024L))
+        assertThatThrownBy(() -> new UploadFileMetadata(invalidFileName, 1024L))
             .isInstanceOf(BaseException.class);
     }
 }

--- a/src/test/java/com/forgather/domain/upload/domain/UploadFileNamePolicyTest.java
+++ b/src/test/java/com/forgather/domain/upload/domain/UploadFileNamePolicyTest.java
@@ -1,0 +1,97 @@
+package com.forgather.domain.upload.domain;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.forgather.global.exception.BaseException;
+
+class UploadFileNamePolicyTest {
+
+    @DisplayName("허용되는 파일명 형식은 예외를 던지지 않는다")
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "abc.jpg",
+        "0.jpg",
+        "550e8400-e29b-41d4-a716-446655440000.png",
+        "a.jpeg",
+        "a.webp",
+        "my_photo (1).jpg",
+        "사진.png",
+        "archive.tar.png",
+        "a..png"
+    })
+    void validFileName(String fileName) {
+        assertThatCode(() -> UploadFileNamePolicy.validate(fileName))
+            .doesNotThrowAnyException();
+    }
+
+    @DisplayName("파일명이 null이거나 비어있으면 예외를 던진다")
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   "})
+    void blankFileName(String fileName) {
+        assertThatThrownBy(() -> UploadFileNamePolicy.validate(fileName))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("null이거나 비어있을 수 없습니다");
+    }
+
+    @DisplayName("경로 조작·허용되지 않은 형식의 파일명은 예외를 던진다")
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "../../../etc/passwd",
+        "a/b.png",
+        "a\\b.png",
+        "noext",
+        "x.gif",
+        "abc.PNG"
+    })
+    void invalidFileName(String fileName) {
+        assertThatThrownBy(() -> UploadFileNamePolicy.validate(fileName))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("올바르지 않은 업로드 파일명 형식");
+    }
+
+    @DisplayName("경로 구분자(/, \\)가 포함된 파일명은 예외를 던진다")
+    @ParameterizedTest
+    @ValueSource(strings = {"a/b.png", "a\\b.png", "../../../config/evil.png", "spaces/1234/x.png"})
+    void rejectsPathSeparator(String fileName) {
+        assertThatThrownBy(() -> UploadFileNamePolicy.validate(fileName))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("올바르지 않은 업로드 파일명 형식");
+    }
+
+    @DisplayName("validateAll은 목록 중 하나라도 형식에 어긋나면 예외를 던진다")
+    @Test
+    void validateAllRejectsAnyInvalid() {
+        List<String> fileNames = List.of("valid.png", "../../../etc/passwd");
+
+        assertThatThrownBy(() -> UploadFileNamePolicy.validateAll(fileNames))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("올바르지 않은 업로드 파일명 형식");
+    }
+
+    @DisplayName("validateAll은 모든 파일명이 유효하면 예외를 던지지 않는다")
+    @Test
+    void validateAllPassesWhenAllValid() {
+        List<String> fileNames = List.of("abc.jpg", "def.jpeg", "ghi.webp");
+
+        assertThatCode(() -> UploadFileNamePolicy.validateAll(fileNames))
+            .doesNotThrowAnyException();
+    }
+
+    @DisplayName("validateAll은 목록이 null이면 예외를 던진다")
+    @Test
+    void validateAllRejectsNullList() {
+        assertThatThrownBy(() -> UploadFileNamePolicy.validateAll(null))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("목록은 null일 수 없습니다");
+    }
+}

--- a/src/test/java/com/forgather/domain/upload/domain/UploadFileNamePolicyTest.java
+++ b/src/test/java/com/forgather/domain/upload/domain/UploadFileNamePolicyTest.java
@@ -43,20 +43,28 @@ class UploadFileNamePolicyTest {
             .hasMessageContaining("null이거나 비어있을 수 없습니다");
     }
 
-    @DisplayName("경로 조작·허용되지 않은 형식의 파일명은 예외를 던진다")
+    @DisplayName("경로 조작, 확장자 없음, 대문자 확장자 등 형식에 어긋난 파일명은 예외를 던진다")
     @ParameterizedTest
     @ValueSource(strings = {
         "../../../etc/passwd",
         "a/b.png",
         "a\\b.png",
         "noext",
-        "x.gif",
         "abc.PNG"
     })
     void invalidFileName(String fileName) {
         assertThatThrownBy(() -> UploadFileNamePolicy.validate(fileName))
             .isInstanceOf(BaseException.class)
             .hasMessageContaining("올바르지 않은 업로드 파일명 형식");
+    }
+
+    @DisplayName("형식은 올바르지만 지원하지 않는 확장자는 예외를 던진다")
+    @ParameterizedTest
+    @ValueSource(strings = {"x.gif", "photo.bmp", "document.pdf", "clip.mp4", "icon.svg"})
+    void unsupportedExtension(String fileName) {
+        assertThatThrownBy(() -> UploadFileNamePolicy.validate(fileName))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("지원하지 않는 이미지 확장자");
     }
 
     @DisplayName("경로 구분자(/, \\)가 포함된 파일명은 예외를 던진다")

--- a/src/test/java/com/forgather/domain/upload/domain/UploadFileNamePolicyTest.java
+++ b/src/test/java/com/forgather/domain/upload/domain/UploadFileNamePolicyTest.java
@@ -3,10 +3,7 @@ package com.forgather.domain.upload.domain;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -73,32 +70,5 @@ class UploadFileNamePolicyTest {
         assertThatThrownBy(() -> UploadFileNamePolicy.validate(fileName))
             .isInstanceOf(BaseException.class)
             .hasMessageContaining("올바르지 않은 업로드 파일명 형식");
-    }
-
-    @DisplayName("validateAll은 목록 중 하나라도 형식에 어긋나면 예외를 던진다")
-    @Test
-    void validateAllRejectsAnyInvalid() {
-        List<String> fileNames = List.of("valid.webp", "../../../etc/passwd");
-
-        assertThatThrownBy(() -> UploadFileNamePolicy.validateAll(fileNames))
-            .isInstanceOf(BaseException.class)
-            .hasMessageContaining("올바르지 않은 업로드 파일명 형식");
-    }
-
-    @DisplayName("validateAll은 모든 파일명이 유효하면 예외를 던지지 않는다")
-    @Test
-    void validateAllPassesWhenAllValid() {
-        List<String> fileNames = List.of("abc.webp", "def.webp", "ghi.webp");
-
-        assertThatCode(() -> UploadFileNamePolicy.validateAll(fileNames))
-            .doesNotThrowAnyException();
-    }
-
-    @DisplayName("validateAll은 목록이 null이면 예외를 던진다")
-    @Test
-    void validateAllRejectsNullList() {
-        assertThatThrownBy(() -> UploadFileNamePolicy.validateAll(null))
-            .isInstanceOf(BaseException.class)
-            .hasMessageContaining("목록은 null일 수 없습니다");
     }
 }

--- a/src/test/java/com/forgather/domain/upload/domain/UploadFileNamePolicyTest.java
+++ b/src/test/java/com/forgather/domain/upload/domain/UploadFileNamePolicyTest.java
@@ -18,15 +18,14 @@ class UploadFileNamePolicyTest {
     @DisplayName("허용되는 파일명 형식은 예외를 던지지 않는다")
     @ParameterizedTest
     @ValueSource(strings = {
-        "abc.jpg",
-        "0.jpg",
-        "550e8400-e29b-41d4-a716-446655440000.png",
-        "a.jpeg",
+        "abc.webp",
+        "0.webp",
+        "550e8400-e29b-41d4-a716-446655440000.webp",
         "a.webp",
-        "my_photo (1).jpg",
-        "사진.png",
-        "archive.tar.png",
-        "a..png"
+        "my_photo (1).webp",
+        "사진.webp",
+        "archive.tar.webp",
+        "a..webp"
     })
     void validFileName(String fileName) {
         assertThatCode(() -> UploadFileNamePolicy.validate(fileName))
@@ -47,10 +46,10 @@ class UploadFileNamePolicyTest {
     @ParameterizedTest
     @ValueSource(strings = {
         "../../../etc/passwd",
-        "a/b.png",
-        "a\\b.png",
+        "a/b.webp",
+        "a\\b.webp",
         "noext",
-        "abc.PNG"
+        "abc.WEBP"
     })
     void invalidFileName(String fileName) {
         assertThatThrownBy(() -> UploadFileNamePolicy.validate(fileName))
@@ -60,7 +59,7 @@ class UploadFileNamePolicyTest {
 
     @DisplayName("형식은 올바르지만 지원하지 않는 확장자는 예외를 던진다")
     @ParameterizedTest
-    @ValueSource(strings = {"x.gif", "photo.bmp", "document.pdf", "clip.mp4", "icon.svg"})
+    @ValueSource(strings = {"photo.png", "photo.jpg", "photo.jpeg", "x.gif", "document.pdf", "icon.svg"})
     void unsupportedExtension(String fileName) {
         assertThatThrownBy(() -> UploadFileNamePolicy.validate(fileName))
             .isInstanceOf(BaseException.class)
@@ -69,7 +68,7 @@ class UploadFileNamePolicyTest {
 
     @DisplayName("경로 구분자(/, \\)가 포함된 파일명은 예외를 던진다")
     @ParameterizedTest
-    @ValueSource(strings = {"a/b.png", "a\\b.png", "../../../config/evil.png", "spaces/1234/x.png"})
+    @ValueSource(strings = {"a/b.webp", "a\\b.webp", "../../../config/evil.webp", "spaces/1234/x.webp"})
     void rejectsPathSeparator(String fileName) {
         assertThatThrownBy(() -> UploadFileNamePolicy.validate(fileName))
             .isInstanceOf(BaseException.class)
@@ -79,7 +78,7 @@ class UploadFileNamePolicyTest {
     @DisplayName("validateAll은 목록 중 하나라도 형식에 어긋나면 예외를 던진다")
     @Test
     void validateAllRejectsAnyInvalid() {
-        List<String> fileNames = List.of("valid.png", "../../../etc/passwd");
+        List<String> fileNames = List.of("valid.webp", "../../../etc/passwd");
 
         assertThatThrownBy(() -> UploadFileNamePolicy.validateAll(fileNames))
             .isInstanceOf(BaseException.class)
@@ -89,7 +88,7 @@ class UploadFileNamePolicyTest {
     @DisplayName("validateAll은 모든 파일명이 유효하면 예외를 던지지 않는다")
     @Test
     void validateAllPassesWhenAllValid() {
-        List<String> fileNames = List.of("abc.jpg", "def.jpeg", "ghi.webp");
+        List<String> fileNames = List.of("abc.webp", "def.webp", "ghi.webp");
 
         assertThatCode(() -> UploadFileNamePolicy.validateAll(fileNames))
             .doesNotThrowAnyException();

--- a/src/test/java/com/forgather/domain/upload/domain/UploadFileTest.java
+++ b/src/test/java/com/forgather/domain/upload/domain/UploadFileTest.java
@@ -17,9 +17,6 @@ class UploadFileTest {
     @DisplayName("파일 확장자로부터 Content-Type을 유도한다")
     @ParameterizedTest
     @CsvSource({
-        "photo.jpg, image/jpeg",
-        "photo.jpeg, image/jpeg",
-        "photo.png, image/png",
         "photo.webp, image/webp"
     })
     void contentType(String fileName, String expectedContentType) {
@@ -32,7 +29,7 @@ class UploadFileTest {
     @ParameterizedTest
     @ValueSource(longs = {1L, 1024L, UploadFile.MAX_FILE_SIZE_BYTES})
     void createWhenSizeWithinLimit(long size) {
-        assertThatCode(() -> new UploadFile("photo.jpg", size))
+        assertThatCode(() -> new UploadFile("photo.webp", size))
             .doesNotThrowAnyException();
     }
 
@@ -41,7 +38,7 @@ class UploadFileTest {
     void throwExceptionWhenSizeExceedsLimit() {
         long oversize = UploadFile.MAX_FILE_SIZE_BYTES + 1;
 
-        assertThatThrownBy(() -> new UploadFile("photo.jpg", oversize))
+        assertThatThrownBy(() -> new UploadFile("photo.webp", oversize))
             .isInstanceOf(BaseException.class)
             .hasMessageContaining("최대");
     }
@@ -50,14 +47,14 @@ class UploadFileTest {
     @ParameterizedTest
     @ValueSource(longs = {0L, -1L})
     void throwExceptionWhenSizeNotPositive(long size) {
-        assertThatThrownBy(() -> new UploadFile("photo.jpg", size))
+        assertThatThrownBy(() -> new UploadFile("photo.webp", size))
             .isInstanceOf(BaseException.class)
             .hasMessageContaining("0보다 커야");
     }
 
     @DisplayName("파일명 형식이 올바르지 않으면 예외를 던진다")
     @ParameterizedTest
-    @ValueSource(strings = {"../../../etc/passwd", "a/b.png", "a\\b.png", "noext", "x.gif"})
+    @ValueSource(strings = {"../../../etc/passwd", "a/b.webp", "a\\b.webp", "noext", "x.gif"})
     void throwExceptionWhenInvalidFileName(String invalidFileName) {
         assertThatThrownBy(() -> new UploadFile(invalidFileName, 1024L))
             .isInstanceOf(BaseException.class);

--- a/src/test/java/com/forgather/domain/upload/domain/UploadFileTest.java
+++ b/src/test/java/com/forgather/domain/upload/domain/UploadFileTest.java
@@ -1,0 +1,65 @@
+package com.forgather.domain.upload.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import com.forgather.global.exception.BaseException;
+
+class UploadFileTest {
+
+    @DisplayName("파일 확장자로부터 Content-Type을 유도한다")
+    @ParameterizedTest
+    @CsvSource({
+        "photo.jpg, image/jpeg",
+        "photo.jpeg, image/jpeg",
+        "photo.png, image/png",
+        "photo.webp, image/webp"
+    })
+    void contentType(String fileName, String expectedContentType) {
+        UploadFile uploadFile = new UploadFile(fileName, 1024L);
+
+        assertThat(uploadFile.getContentType()).isEqualTo(expectedContentType);
+    }
+
+    @DisplayName("파일 크기가 최대 크기(20MB) 이하이면 생성된다")
+    @ParameterizedTest
+    @ValueSource(longs = {1L, 1024L, UploadFile.MAX_FILE_SIZE_BYTES})
+    void createWhenSizeWithinLimit(long size) {
+        assertThatCode(() -> new UploadFile("photo.jpg", size))
+            .doesNotThrowAnyException();
+    }
+
+    @DisplayName("파일 크기가 최대 크기(20MB)를 초과하면 예외를 던진다")
+    @Test
+    void throwExceptionWhenSizeExceedsLimit() {
+        long oversize = UploadFile.MAX_FILE_SIZE_BYTES + 1;
+
+        assertThatThrownBy(() -> new UploadFile("photo.jpg", oversize))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("최대");
+    }
+
+    @DisplayName("파일 크기가 0 이하이면 예외를 던진다")
+    @ParameterizedTest
+    @ValueSource(longs = {0L, -1L})
+    void throwExceptionWhenSizeNotPositive(long size) {
+        assertThatThrownBy(() -> new UploadFile("photo.jpg", size))
+            .isInstanceOf(BaseException.class)
+            .hasMessageContaining("0보다 커야");
+    }
+
+    @DisplayName("파일명 형식이 올바르지 않으면 예외를 던진다")
+    @ParameterizedTest
+    @ValueSource(strings = {"../../../etc/passwd", "a/b.png", "a\\b.png", "noext", "x.gif"})
+    void throwExceptionWhenInvalidFileName(String invalidFileName) {
+        assertThatThrownBy(() -> new UploadFile(invalidFileName, 1024L))
+            .isInstanceOf(BaseException.class);
+    }
+}

--- a/src/test/java/com/forgather/fake/FakeContentStorage.java
+++ b/src/test/java/com/forgather/fake/FakeContentStorage.java
@@ -28,6 +28,11 @@ public class FakeContentStorage implements ContentsStorage {
     }
 
     @Override
+    public String issueSignedUrl(String path, String contentType, long contentLength) {
+        return "test-prefix-" + path + "-test-suffix";
+    }
+
+    @Override
     public String getRootDirectory() {
         return "photogather/v2";
     }


### PR DESCRIPTION
## 연관된 이슈

- close #98 

## 작업 내용

presigned URL 발급 API를 방명록, 작품, 전시 도메인별로 발급 엔드포인트를 분리했습니다. 발급 단계에서 파일명 형식, 확장자(webp), 크기(20MB), Content-Type/Length를 검증하고 강제합니다.

## 변경 사항

- 도메인별 사진 업로드 presigned URL 발급 API 신설 (방명록 / 작품 / 전시)
- presigned PUT URL에 `Content-Type`, `Content-Length`를 서명으로 고정해 임의 MIME 타입, 대용량 업로드 차단
- 업로드 가능한 확장자를 `webp`로 단일화 + 파일명 형식 검증으로 경로 조작 차단
- 업로드 파일 크기 상한 20MB 적용 (`UploadFile` 값 객체)
  - webp로 리사이징된 이미지라 훨씬 적은 용량이지만 보수적으로 이미지 크기를 잡았습니다. 기존에 존재하지 않던 대용량 파일 업로드를 차단했다는 점에 의의를 두었습니다
- 작품 사진 업로드 URL 발급 시 스페이스 호스트 권한 검증 추가
- 요청 DTO Bean Validation 적용 (`@NotEmpty`, `@Valid`, `@Pattern`, `@NotBlank`, `@Positive`, `@Max`)
- 전시 생성 시 사진 `path`를 서버에서 조립 후 저장하도록 변경 (`UploadCategory.EXHIBITION` 추가)
- 레거시 단일 발급 엔드포인트 `@Deprecated(forRemoval = true)` 처리
- DB를 조회하는 발급 서비스 메서드에 `@Transactional(readOnly = true)` 적용
- 업로드 인수/단위 테스트 추가

## 작업 내용

### 도메인별 presigned URL 발급 API 분리

기존 단일 엔드포인트를 사진 용도별로 분리하고, 용도에 맞는 인증/권한을 적용합니다.

| 엔드포인트 | 용도 | 인증 |
|---|---|---|
| `POST /spaces/{spaceCode}/guestbooks/upload/signed-urls` | 방명록 사진 | 무인증 (방문객 허용) |
| `POST /spaces/{spaceCode}/products/upload/signed-urls` | 작품 사진 | 호스트 인증 + 소유 검증 |
| `POST /exhibitions/upload/signed-urls` | 전시 사진 | 호스트 인증 |
| `POST /spaces/{spaceCode}/upload/signed-urls` | (레거시) | `@Deprecated(forRemoval)` |

업로드 경로(S3 key)는 발급 단계에서 서버가 조립합니다.

- 스페이스 기반: `{root}/spaces/{spaceCode}/{category}/{fileName}`
- 전시: `{root}/exhibitions/host-{hostId}/{fileName}`

---

### Content-Type / Content-Length 서명 고정

발급되는 presigned PUT URL의 서명에 `Content-Type`과 `Content-Length`를 포함합니다. (AWS SDK for Java v2는 두 값을 서명된 헤더로 취급합니다.)

- 클라이언트는 PUT 시 **동일한 Content-Type 헤더**와 **정확히 요청한 바이트 수**의 본문을 보내야 합니다.
- 불일치 시 S3가 `403 SignatureDoesNotMatch`로 거부합니다.
- 발급 크기는 요청 단계에서 `@Max(20MB)`로 먼저 검증되므로, 임의 MIME 타입 업로드와 대용량 업로드를 모두 차단합니다.

확장자 → Content-Type 매핑: `webp → image/webp`

---

### 업로드 파일 검증 정책 (두 계층)

검증 실패는 위반한 계층에 따라 응답 코드가 갈립니다.

| 계층 | 검증 | 위반 예 | 응답 코드 |
|---|---|---|---|
| Bean Validation | `@Pattern`(형식) · `@NotBlank` · `@NotEmpty` · `@Positive` · `@Max` | 경로 조작·대문자 확장자·빈 목록·0 이하/20MB 초과 크기 | `VALIDATION_FAILED` |
| 도메인 검증 | `ImageContentType` (`UploadFileNamePolicy.validate`) | 형식은 맞지만 webp가 아닌 확장자 | `BAD_REQUEST` |

**[파일명 형식]**
`UploadFileNamePolicy.FILENAME_PATTERN`으로 경로 구분자(`/`, `\`)·상위 경로(`../`)를 차단하고 소문자 확장자만 허용합니다.

**[확장자]**
 FE 협의에 따라 현재 `webp`만 허용하며(클라이언트가 서비스에 맞게 리사이즈한 webp로만 업로드), 확장자 추가/변경은 이 enum만 수정하면 됩니다.

**[크기]**
`UploadFile` 값 객체가 0 이하·20MB 초과를 거부하고, 파일명으로부터 Content-Type을 유도합니다.

---

### 작품 사진 호스트 권한 검증

작품 사진 발급은 해당 스페이스의 호스트만 가능합니다. `UploadService.validateSpaceHost`가 `SpaceHost` 소유 관계를 확인하고, 비소유 호스트의 요청은 `403`(`ForbiddenException`)으로 거부합니다.

---

### 전시 생성 사진 path 서버 조립

전시 생성 요청이 이미지 `path`를 직접 받던 것을, **업로드 파일명만 받고 서버가 path를 조립**하도록 변경했습니다.

**[변경 내용]**
- `CreateExhibitionRequest`에서 이미지 `path` 직접 전달을 제거하고 `CreateExhibitionPhotoRequest(uploadFileName, capacity)`로 캡슐화
- path는 `FilePathGenerator.generateExhibitionContentsFilePath(...)`로 서버에서 조립 후 `ExhibitionPhoto` 저장
- `UploadCategory.EXHIBITION` 추가

---

### 레거시 API deprecated

신규 도메인별 엔드포인트 도입에 따라, 기존 단일 발급 경로(`POST /spaces/{spaceCode}/upload/signed-urls`)와 그 호출 체인(컨트롤러 · 서비스 · `SignedUrlIssuer#issueSignedUrls`)을 `@Deprecated(forRemoval = true)`로 표시했습니다.

해당 경로는 Content-Type/크기 강제가 없는 구버전 흐름(`List<String>` 입력, 1-arg presign)으로, 신규 엔드포인트 안정화 후 제거 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 전시 사진을 포함해 카테고리별(방명록/작품/전시) 업로드 signed URL 발급 API 제공
  * 업로드 요청을 파일명·용량 기준으로 받아 파일별 signed URL을 발급
  * 이미지 WEBP 형식 지원 추가

* **개선 사항**
  * 업로드 파일명 형식과 파일 크기(최대 20MB) 유효성 검증 강화
  * 전시 응답의 대표 이미지 필드가 `photoPath`로 변경(미설정 시 `null`)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->