### PR TITLE
refactor: 읽지 않은 방명록 조회 분리하도록 수정 

### DIFF
--- a/src/main/java/com/forgather/domain/guestbook/controller/SpaceGuestbookController.java
+++ b/src/main/java/com/forgather/domain/guestbook/controller/SpaceGuestbookController.java
@@ -84,7 +84,7 @@ public class SpaceGuestbookController {
         Pageable pageable,
         @LoginHost(required = false) Host host
     ) {
-        GuestBookResponse response = guestBookService.read(host, spaceCode, pageable);
+        var response = guestBookService.read(host, spaceCode, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -99,7 +99,7 @@ public class SpaceGuestbookController {
         Pageable pageable,
         @LoginHost(required = false) Host host
     ) {
-        GuestBookResponse response = guestBookService.readV2(host, spaceCode, pageable);
+        var response = guestBookService.readV2(host, spaceCode, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -113,7 +113,7 @@ public class SpaceGuestbookController {
         Pageable pageable,
         @LoginHost(required = true) Host host
     ) {
-        GuestBookResponse response = guestBookService.readUnread(host, spaceCode, pageable);
+        var response = guestBookService.readUnread(host, spaceCode, pageable);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
@@ -125,7 +125,7 @@ public class SpaceGuestbookController {
         @PathVariable(value = "guestBookCardId") Long guestBookCardId,
         @LoginHost(required = false) Host host
     ) {
-        GuestBookCardResponse response = guestBookService.readCard(host, spaceCode, guestBookCardId);
+        var response = guestBookService.readCard(host, spaceCode, guestBookCardId);
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 

--- a/src/main/java/com/forgather/domain/guestbook/controller/SpaceGuestbookController.java
+++ b/src/main/java/com/forgather/domain/guestbook/controller/SpaceGuestbookController.java
@@ -48,7 +48,7 @@ public class SpaceGuestbookController {
     private final GuestBookService guestBookService;
     private final GuestbookReportService guestBookReportService;
 
-    @Deprecated(since = "2026-06-11", forRemoval = true)
+    @Deprecated(forRemoval = true)
     @Hidden
     @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "방명록 조회",

--- a/src/main/java/com/forgather/domain/guestbook/controller/SpaceGuestbookController.java
+++ b/src/main/java/com/forgather/domain/guestbook/controller/SpaceGuestbookController.java
@@ -49,7 +49,7 @@ public class SpaceGuestbookController {
 
     @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "방명록 조회",
-        description = "공개 스페이스가 아닌 경우 호스트만 조회 가능, 방문자는 isRead 필드 누락",
+        description = "공개 스페이스가 아닌 경우 호스트만 조회 가능. 호스트일 경우 읽은 방명록은 조회하지 않는다.",
         parameters = {
             @Parameter(
                 name = "page",

--- a/src/main/java/com/forgather/domain/guestbook/controller/SpaceGuestbookController.java
+++ b/src/main/java/com/forgather/domain/guestbook/controller/SpaceGuestbookController.java
@@ -27,6 +27,7 @@ import com.forgather.global.auth.annotation.LoginHost;
 import com.forgather.global.auth.model.Host;
 import com.forgather.global.response.ApiResponse;
 
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -47,9 +48,12 @@ public class SpaceGuestbookController {
     private final GuestBookService guestBookService;
     private final GuestbookReportService guestBookReportService;
 
+    @Deprecated(since = "2026-06-11", forRemoval = true)
+    @Hidden
     @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "방명록 조회",
-        description = "공개 스페이스가 아닌 경우 호스트만 조회 가능. 호스트일 경우 읽은 방명록은 조회하지 않는다.",
+        description = "공개 스페이스가 아닌 경우 호스트만 조회 가능. 하위 호환을 위한 기존 API이며 신규 클라이언트는 X-API-Version=2로 호출한다.",
+        deprecated = true,
         parameters = {
             @Parameter(
                 name = "page",
@@ -72,6 +76,7 @@ public class SpaceGuestbookController {
         }
     )
     @GetMapping
+    @SuppressWarnings("removal")
     public ResponseEntity<ApiResponse<GuestBookResponse>> readGuestBook(
         @PathVariable(value = "spaceCode") String spaceCode,
         @Parameter(hidden = true)
@@ -84,10 +89,26 @@ public class SpaceGuestbookController {
     }
 
     @SecurityRequirement(name = "bearerAuth")
+    @Operation(summary = "방명록 조회 v2",
+        description = "공개 스페이스가 아닌 경우 호스트만 조회 가능. 호스트일 경우 읽은 방명록만 조회하고 읽지 않은 방명록 수를 응답한다.")
+    @GetMapping(headers = "X-API-Version=2")
+    public ResponseEntity<ApiResponse<GuestBookResponse>> readGuestBookV2(
+        @PathVariable(value = "spaceCode") String spaceCode,
+        @Parameter(hidden = true)
+        @PageableDefault(size = 15, sort = {"createdAt", "id"}, direction = Sort.Direction.DESC)
+        Pageable pageable,
+        @LoginHost(required = false) Host host
+    ) {
+        GuestBookResponse response = guestBookService.readV2(host, spaceCode, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "읽지 않은 방명록 조회", description = "스페이스 호스트가 읽지 않은 방명록 목록을 조회한다")
     @GetMapping("/unread")
     public ResponseEntity<ApiResponse<GuestBookResponse>> readUnreadGuestBook(
         @PathVariable(value = "spaceCode") String spaceCode,
+        @Parameter(hidden = true)
         @PageableDefault(size = 15, sort = {"createdAt", "id"}, direction = Sort.Direction.DESC)
         Pageable pageable,
         @LoginHost(required = true) Host host

--- a/src/main/java/com/forgather/domain/guestbook/controller/SpaceGuestbookController.java
+++ b/src/main/java/com/forgather/domain/guestbook/controller/SpaceGuestbookController.java
@@ -84,6 +84,19 @@ public class SpaceGuestbookController {
     }
 
     @SecurityRequirement(name = "bearerAuth")
+    @Operation(summary = "읽지 않은 방명록 조회", description = "스페이스 호스트가 읽지 않은 방명록 목록을 조회한다")
+    @GetMapping("/unread")
+    public ResponseEntity<ApiResponse<GuestBookResponse>> readUnreadGuestBook(
+        @PathVariable(value = "spaceCode") String spaceCode,
+        @PageableDefault(size = 15, sort = {"createdAt", "id"}, direction = Sort.Direction.DESC)
+        Pageable pageable,
+        @LoginHost(required = true) Host host
+    ) {
+        GuestBookResponse response = guestBookService.readUnread(host, spaceCode, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @SecurityRequirement(name = "bearerAuth")
     @Operation(summary = "방명록 카드 조회", description = "공개 스페이스가 아닌 경우 호스트만 조회 가능")
     @GetMapping("/{guestBookCardId}")
     public ResponseEntity<ApiResponse<GuestBookCardResponse>> readCard(

--- a/src/main/java/com/forgather/domain/guestbook/dto/GuestBookCardSimpleResponse.java
+++ b/src/main/java/com/forgather/domain/guestbook/dto/GuestBookCardSimpleResponse.java
@@ -1,6 +1,6 @@
 package com.forgather.domain.guestbook.dto;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
+import com.forgather.domain.guestbook.repository.dto.GuestBookCardListDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -12,10 +12,14 @@ public record GuestBookCardSimpleResponse(
     String nickname,
 
     @Schema(description = "사진 포함 여부", example = "false")
-    Boolean containsPhoto,
-
-    @Schema(description = "호스트 읽음 여부", example = "false")
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    Boolean isRead
+    Boolean containsPhoto
 ) {
+
+    public static GuestBookCardSimpleResponse from(GuestBookCardListDto guestBookCardDto) {
+        return new GuestBookCardSimpleResponse(
+            guestBookCardDto.id(),
+            guestBookCardDto.nickname(),
+            guestBookCardDto.isPhotoExists()
+        );
+    }
 }

--- a/src/main/java/com/forgather/domain/guestbook/dto/GuestBookCardSimpleResponse.java
+++ b/src/main/java/com/forgather/domain/guestbook/dto/GuestBookCardSimpleResponse.java
@@ -29,7 +29,7 @@ public record GuestBookCardSimpleResponse(
         );
     }
 
-    @Deprecated(since = "2026-06-11", forRemoval = true)
+    @Deprecated(forRemoval = true)
     public static GuestBookCardSimpleResponse fromWithReadStatus(GuestBookCardListDto guestBookCardDto) {
         return new GuestBookCardSimpleResponse(
             guestBookCardDto.id(),

--- a/src/main/java/com/forgather/domain/guestbook/dto/GuestBookCardSimpleResponse.java
+++ b/src/main/java/com/forgather/domain/guestbook/dto/GuestBookCardSimpleResponse.java
@@ -1,5 +1,6 @@
 package com.forgather.domain.guestbook.dto;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.forgather.domain.guestbook.repository.dto.GuestBookCardListDto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -12,14 +13,29 @@ public record GuestBookCardSimpleResponse(
     String nickname,
 
     @Schema(description = "사진 포함 여부", example = "false")
-    Boolean containsPhoto
+    Boolean containsPhoto,
+
+    @Schema(description = "호스트 읽음 여부", example = "false")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    Boolean isRead
 ) {
 
     public static GuestBookCardSimpleResponse from(GuestBookCardListDto guestBookCardDto) {
         return new GuestBookCardSimpleResponse(
             guestBookCardDto.id(),
             guestBookCardDto.nickname(),
-            guestBookCardDto.isPhotoExists()
+            guestBookCardDto.isPhotoExists(),
+            null
+        );
+    }
+
+    @Deprecated(since = "2026-06-11", forRemoval = true)
+    public static GuestBookCardSimpleResponse fromWithReadStatus(GuestBookCardListDto guestBookCardDto) {
+        return new GuestBookCardSimpleResponse(
+            guestBookCardDto.id(),
+            guestBookCardDto.nickname(),
+            guestBookCardDto.isPhotoExists(),
+            guestBookCardDto.isRead()
         );
     }
 }

--- a/src/main/java/com/forgather/domain/guestbook/dto/GuestBookResponse.java
+++ b/src/main/java/com/forgather/domain/guestbook/dto/GuestBookResponse.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record GuestBookResponse(
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Schema(description = "읽지 않은 방명록 카드 개수", example = "3")
-    Long newCount,
+    Long unreadCount,
 
     @Schema(description = "방명록 카드 목록", example = """
         [
@@ -51,8 +51,8 @@ public record GuestBookResponse(
         this(guestBookCards, null);
     }
 
-    public GuestBookResponse(Page<GuestBookCardSimpleResponse> guestBookCards, Long newCount) {
-        this(newCount,
+    public GuestBookResponse(Page<GuestBookCardSimpleResponse> guestBookCards, Long unreadCount) {
+        this(unreadCount,
             guestBookCards.toList(),
             guestBookCards.getNumber() + 1,
             guestBookCards.getSize(),

--- a/src/main/java/com/forgather/domain/guestbook/dto/GuestBookResponse.java
+++ b/src/main/java/com/forgather/domain/guestbook/dto/GuestBookResponse.java
@@ -4,28 +4,31 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record GuestBookResponse(
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    @Schema(description = "읽지 않은 방명록 카드 개수", example = "3")
+    Long newCount,
+
     @Schema(description = "방명록 카드 목록", example = """
         [
             {
               "id": 1,
               "nickname": "밍퐁루블",
-              "containsPhoto": false,
-              "isRead": false
+              "containsPhoto": false
             },
             {
               "id": 2,
               "nickname": "레오",
-              "containsPhoto": true,
-              "isRead": false
+              "containsPhoto": true
             },
             {
               "id": 3,
               "nickname": "포스티",
-              "containsPhoto": true,
-              "isRead": true
+              "containsPhoto": true
             }
           ]
         """)
@@ -45,7 +48,12 @@ public record GuestBookResponse(
 ) {
 
     public GuestBookResponse(Page<GuestBookCardSimpleResponse> guestBookCards) {
-        this(guestBookCards.toList(),
+        this(guestBookCards, null);
+    }
+
+    public GuestBookResponse(Page<GuestBookCardSimpleResponse> guestBookCards, Long newCount) {
+        this(newCount,
+            guestBookCards.toList(),
             guestBookCards.getNumber() + 1,
             guestBookCards.getSize(),
             guestBookCards.getTotalElements(),

--- a/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
+++ b/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
@@ -48,7 +48,7 @@ public interface GuestBookCardRepository {
                 g.nickname,
                 g.isRead,
                 CASE WHEN (
-                    SELECT COUNT(p) FROM GuestBookCardPhoto p WHERE p.guestBookCard = g
+                    SELECT COUNT(p) FROM GuestBookCardPhoto p WHERE p.guestBookCard = g AND p.deletedAt IS NULL
                 ) > 0 THEN true ELSE false END
             )
             FROM GuestBookCard g
@@ -68,7 +68,7 @@ public interface GuestBookCardRepository {
                 g.nickname,
                 g.isRead,
                 CASE WHEN (
-                    SELECT COUNT(p) FROM GuestBookCardPhoto p WHERE p.guestBookCard = g
+                    SELECT COUNT(p) FROM GuestBookCardPhoto p WHERE p.guestBookCard = g AND p.deletedAt IS NULL
                 ) > 0 THEN true ELSE false END
             )
             FROM GuestBookCard g

--- a/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
+++ b/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
@@ -46,7 +46,6 @@ public interface GuestBookCardRepository {
             SELECT new com.forgather.domain.guestbook.repository.dto.GuestBookCardListDto(
                 g.id,
                 g.nickname,
-                g.isRead,
                 CASE WHEN (
                     SELECT COUNT(p) FROM GuestBookCardPhoto p WHERE p.guestBookCard = g
                 ) > 0 THEN true ELSE false END
@@ -60,6 +59,33 @@ public interface GuestBookCardRepository {
         @Param("space") Space space,
         @Param("visibilityStatus") VisibilityStatus visibilityStatus,
         Pageable pageable
+    );
+
+    @Query("""
+            SELECT new com.forgather.domain.guestbook.repository.dto.GuestBookCardListDto(
+                g.id,
+                g.nickname,
+                CASE WHEN (
+                    SELECT COUNT(p) FROM GuestBookCardPhoto p WHERE p.guestBookCard = g
+                ) > 0 THEN true ELSE false END
+            )
+            FROM GuestBookCard g
+            WHERE g.space = :space
+                AND g.visibilityStatus = :visibilityStatus
+                AND g.isRead = :isRead
+                AND g.deletedAt IS NULL
+        """)
+    Page<GuestBookCardListDto> findAllDtoBySpaceAndVisibilityStatusAndIsReadAndDeletedAtIsNull(
+        @Param("space") Space space,
+        @Param("visibilityStatus") VisibilityStatus visibilityStatus,
+        @Param("isRead") boolean isRead,
+        Pageable pageable
+    );
+
+    long countBySpaceAndVisibilityStatusAndIsReadAndDeletedAtIsNull(
+        Space space,
+        VisibilityStatus visibilityStatus,
+        boolean isRead
     );
 
     List<GuestBookCard> findAllBySpaceAndDeletedAtIsNull(Space space);

--- a/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
+++ b/src/main/java/com/forgather/domain/guestbook/repository/GuestBookCardRepository.java
@@ -46,6 +46,7 @@ public interface GuestBookCardRepository {
             SELECT new com.forgather.domain.guestbook.repository.dto.GuestBookCardListDto(
                 g.id,
                 g.nickname,
+                g.isRead,
                 CASE WHEN (
                     SELECT COUNT(p) FROM GuestBookCardPhoto p WHERE p.guestBookCard = g
                 ) > 0 THEN true ELSE false END
@@ -65,6 +66,7 @@ public interface GuestBookCardRepository {
             SELECT new com.forgather.domain.guestbook.repository.dto.GuestBookCardListDto(
                 g.id,
                 g.nickname,
+                g.isRead,
                 CASE WHEN (
                     SELECT COUNT(p) FROM GuestBookCardPhoto p WHERE p.guestBookCard = g
                 ) > 0 THEN true ELSE false END

--- a/src/main/java/com/forgather/domain/guestbook/repository/dto/GuestBookCardListDto.java
+++ b/src/main/java/com/forgather/domain/guestbook/repository/dto/GuestBookCardListDto.java
@@ -3,7 +3,6 @@ package com.forgather.domain.guestbook.repository.dto;
 public record GuestBookCardListDto(
     Long id,
     String nickname,
-    boolean isRead,
     boolean isPhotoExists
 ) {
 }

--- a/src/main/java/com/forgather/domain/guestbook/repository/dto/GuestBookCardListDto.java
+++ b/src/main/java/com/forgather/domain/guestbook/repository/dto/GuestBookCardListDto.java
@@ -3,6 +3,7 @@ package com.forgather.domain.guestbook.repository.dto;
 public record GuestBookCardListDto(
     Long id,
     String nickname,
+    boolean isRead,
     boolean isPhotoExists
 ) {
 }

--- a/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -77,7 +77,7 @@ public class GuestBookService {
         return new GuestBookCardPhotos(photos);
     }
 
-    @Deprecated(since = "2026-06-11", forRemoval = true)
+    @Deprecated(forRemoval = true)
     @Transactional(readOnly = true)
     @SuppressWarnings("removal")
     public GuestBookResponse read(Host host, String spaceCode, Pageable pageable) {

--- a/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -117,6 +117,25 @@ public class GuestBookService {
         return new GuestBookResponse(simpleResponses);
     }
 
+    /**
+     * 스페이스 호스트인 경우에만 isRead=false인 방명록 조회
+     */
+    @Transactional(readOnly = true)
+    public GuestBookResponse readUnread(Host host, String spaceCode, Pageable pageable) {
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
+        validateSpaceHost(host, space);
+
+        Page<GuestBookCardSimpleResponse> unreadResponses =
+            guestBookCardRepository.findAllDtoBySpaceAndVisibilityStatusAndIsReadAndDeletedAtIsNull(
+                space,
+                VISIBLE,
+                false,
+                pageable
+            ).map(GuestBookCardSimpleResponse::from);
+
+        return new GuestBookResponse(unreadResponses);
+    }
+
     @Transactional
     public GuestBookCardResponse readCard(Host host, String spaceCode, Long guestBookCardId) {
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);

--- a/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -120,13 +120,13 @@ public class GuestBookService {
                     pageable
                 ).map(GuestBookCardSimpleResponse::from);
 
-            long newCount = guestBookCardRepository.countBySpaceAndVisibilityStatusAndIsReadAndDeletedAtIsNull(
+            long unreadCount = guestBookCardRepository.countBySpaceAndVisibilityStatusAndIsReadAndDeletedAtIsNull(
                 space,
                 VISIBLE,
                 false
             );
 
-            return new GuestBookResponse(readResponses, newCount);
+            return new GuestBookResponse(readResponses, unreadCount);
         }
 
         // 방문객: 읽음 여부와 상관 없이 모두 조회, 안읽은 방명록 개수 응답 x

--- a/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -1,5 +1,6 @@
 package com.forgather.domain.guestbook.service;
 
+import static com.forgather.domain.guestbook.model.VisibilityStatus.VISIBLE;
 import static com.forgather.domain.upload.domain.FilePathGenerator.generateContentsFilePath;
 import static com.forgather.domain.upload.domain.UploadCategory.GUESTBOOK;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
@@ -23,16 +24,13 @@ import com.forgather.domain.guestbook.exception.GuestbookCardNotReadableExceptio
 import com.forgather.domain.guestbook.model.GuestBookCard;
 import com.forgather.domain.guestbook.model.GuestBookCardPhoto;
 import com.forgather.domain.guestbook.model.GuestBookCardPhotos;
-import com.forgather.domain.guestbook.model.VisibilityStatus;
 import com.forgather.domain.guestbook.repository.GuestBookCardPhotoRepository;
 import com.forgather.domain.guestbook.repository.GuestBookCardRepository;
-import com.forgather.domain.guestbook.repository.dto.GuestBookCardListDto;
 import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.SpaceRepository;
 import com.forgather.domain.upload.domain.ContentsStorage;
 import com.forgather.global.auth.model.Host;
 import com.forgather.global.auth.repository.SpaceHostRepository;
-import com.forgather.global.exception.BaseException;
 import com.forgather.global.exception.BaseNullPointerException;
 import com.forgather.global.exception.ForbiddenException;
 import com.forgather.global.exception.NotFoundException;
@@ -79,25 +77,43 @@ public class GuestBookService {
         return new GuestBookCardPhotos(photos);
     }
 
+    /**
+     *  VISIBLE 상태인 방명록 조회
+     * - 스페이스 호스트: isRead=true인 방명록만 조회, isRead=false인 방명록 개수 응답
+     * - 게스트: 모든 방명록 조회, 안읽은 방명록 개수 응답x
+     */
     @Transactional(readOnly = true)
     public GuestBookResponse read(Host host, String spaceCode, Pageable pageable) {
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         boolean isSpaceHost = host != null && isSpaceHost(space, host);
         validateCanRead(space, isSpaceHost);
-        Page<GuestBookCardListDto> guestBookCardDtos =
+
+        if (isSpaceHost) { // 스페이스 호스트: 읽은 방명록만 조회, 안읽은 방명록 개수 응답
+            Page<GuestBookCardSimpleResponse> readResponses =
+                guestBookCardRepository.findAllDtoBySpaceAndVisibilityStatusAndIsReadAndDeletedAtIsNull(
+                    space,
+                    VISIBLE,
+                    true,
+                    pageable
+                ).map(GuestBookCardSimpleResponse::from);
+
+            long newCount = guestBookCardRepository.countBySpaceAndVisibilityStatusAndIsReadAndDeletedAtIsNull(
+                space,
+                VISIBLE,
+                false
+            );
+
+            return new GuestBookResponse(readResponses, newCount);
+        }
+
+        // 방문객: 읽음 여부와 상관 없이 모두 조회, 안읽은 방명록 개수 응답 x
+        Page<GuestBookCardSimpleResponse> simpleResponses =
             guestBookCardRepository.findAllDtoBySpaceAndVisibilityStatusAndDeletedAtIsNull(
                 space,
-                VisibilityStatus.VISIBLE,
+                VISIBLE,
                 pageable
-            );
-        Page<GuestBookCardSimpleResponse> simpleResponses = guestBookCardDtos.map(
-            guestBookCardDto -> new GuestBookCardSimpleResponse(
-                guestBookCardDto.id(),
-                guestBookCardDto.nickname(),
-                guestBookCardDto.isPhotoExists(),
-                isSpaceHost ? guestBookCardDto.isRead() : null
-            )
-        );
+            ).map(GuestBookCardSimpleResponse::from);
+
         return new GuestBookResponse(simpleResponses);
     }
 

--- a/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
+++ b/src/main/java/com/forgather/domain/guestbook/service/GuestBookService.java
@@ -77,13 +77,36 @@ public class GuestBookService {
         return new GuestBookCardPhotos(photos);
     }
 
+    @Deprecated(since = "2026-06-11", forRemoval = true)
+    @Transactional(readOnly = true)
+    @SuppressWarnings("removal")
+    public GuestBookResponse read(Host host, String spaceCode, Pageable pageable) {
+        Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
+        boolean isSpaceHost = host != null && isSpaceHost(space, host);
+        validateCanRead(space, isSpaceHost);
+
+        Page<GuestBookCardSimpleResponse> simpleResponses =
+            guestBookCardRepository.findAllDtoBySpaceAndVisibilityStatusAndDeletedAtIsNull(
+                space,
+                VISIBLE,
+                pageable
+            ).map(guestBookCardDto -> {
+                if (isSpaceHost) {
+                    return GuestBookCardSimpleResponse.fromWithReadStatus(guestBookCardDto);
+                }
+                return GuestBookCardSimpleResponse.from(guestBookCardDto);
+            });
+
+        return new GuestBookResponse(simpleResponses);
+    }
+
     /**
-     *  VISIBLE 상태인 방명록 조회
+     * VISIBLE 상태인 방명록 조회
      * - 스페이스 호스트: isRead=true인 방명록만 조회, isRead=false인 방명록 개수 응답
      * - 게스트: 모든 방명록 조회, 안읽은 방명록 개수 응답x
      */
     @Transactional(readOnly = true)
-    public GuestBookResponse read(Host host, String spaceCode, Pageable pageable) {
+    public GuestBookResponse readV2(Host host, String spaceCode, Pageable pageable) {
         Space space = spaceRepository.getByCodeAndDeletedAtIsNullOrThrow(spaceCode);
         boolean isSpaceHost = host != null && isSpaceHost(space, host);
         validateCanRead(space, isSpaceHost);

--- a/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -1,5 +1,6 @@
 package com.forgather.acceptance;
 
+import static com.forgather.domain.guestbook.model.GuestBookReportReason.ADVERTISEMENT_SPAM;
 import static com.forgather.domain.guestbook.model.VisibilityStatus.HIDDEN_BY_ADMIN;
 import static com.forgather.domain.guestbook.model.VisibilityStatus.HIDDEN_BY_HOST;
 import static com.forgather.fixture.GuestBookCardFixture.createWithSpaceAndVisibilityStatus;
@@ -29,7 +30,6 @@ import com.forgather.domain.guestbook.dto.WriteGuestBookCardPhotoRequest;
 import com.forgather.domain.guestbook.dto.WriteGuestBookCardRequest;
 import com.forgather.domain.guestbook.dto.WriteGuestBookCardResponse;
 import com.forgather.domain.guestbook.model.GuestBookCard;
-import com.forgather.domain.guestbook.model.GuestBookReportReason;
 import com.forgather.domain.guestbook.repository.GuestBookCardRepository;
 import com.forgather.domain.space.model.Space;
 import com.forgather.domain.space.repository.HostRepository;
@@ -887,7 +887,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
     }
 
     private void reportGuestBookCard(Space space, Long guestBookCardId) {
-        CreateGuestBookReportRequest request = new CreateGuestBookReportRequest(GuestBookReportReason.ADVERTISEMENT_SPAM, null);
+        CreateGuestBookReportRequest request = new CreateGuestBookReportRequest(ADVERTISEMENT_SPAM, null);
 
         RestAssuredMockMvc.given()
             .header("Authorization", "Bearer " + accessToken)

--- a/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -166,7 +166,9 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .asString();
 
             // then
-            assertThat(response).doesNotContain("\"newCount\"");
+            assertAll(
+                () -> assertThat(response).doesNotContain("\"unreadCount\"")
+            );
         }
 
         @DisplayName("방문자 조회 시 방명록은 각 방명록 카드의 방문자 닉네임과 사진 여부를 포함한다")
@@ -362,7 +364,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
 
             // then
             assertAll(
-                () -> assertThat(result.data().newCount()).isNull(),
+                () -> assertThat(result.data().unreadCount()).isNull(),
                 () -> assertThat(result.data().guestBookCards()).hasSize(1),
                 () -> assertThat(result.data().guestBookCards().getFirst().id()).isEqualTo(unreadCard.id()),
                 () -> assertThat(result.data().guestBookCards().getFirst().isRead()).isNull(),
@@ -545,7 +547,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .statusCode(200);
 
             // then
-            ApiResponse<GuestBookResponse> result = RestAssuredMockMvc.given()
+            String response = RestAssuredMockMvc.given()
                 .header("X-API-Version", "2")
                 .header("Authorization", "Bearer " + accessToken)
                 .accept(ContentType.JSON)
@@ -559,14 +561,13 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .statusCode(200)
                 .extract()
                 .body()
-                .as(new TypeRef<>() {
-                });
+                .asString();
 
             assertAll(
-                () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
-                () -> assertThat(result.message()).isNull(),
-                () -> assertThat(result.data().newCount()).isZero(),
-                () -> assertThat(result.data().guestBookCards().getFirst().id()).isEqualTo(writeResponse.id())
+                () -> assertThat(response).contains("\"code\":\"SUCCESS\""),
+                () -> assertThat(response).contains("\"unreadCount\":0"),
+                () -> assertThat(response).doesNotContain("\"newCount\""),
+                () -> assertThat(response).contains("\"id\":%d".formatted(writeResponse.id()))
             );
         }
     }

--- a/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -333,6 +333,39 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
             );
         }
 
+        @DisplayName("호스트는 읽지 않은 방명록 목록을 조회할 수 있다")
+        @Test
+        void hostCanReadUnreadGuestBookCards() {
+            // given
+            WriteGuestBookCardResponse readCard = writeGuestBookCard(publicSpace);
+            WriteGuestBookCardResponse unreadCard = writeGuestBookCardWithNoPhoto(publicSpace);
+            readGuestBookCardAsHost(publicSpace, readCard.id());
+
+            // when
+            ApiResponse<GuestBookResponse> result = RestAssuredMockMvc.given()
+                .header("Authorization", "Bearer " + accessToken)
+                .accept(ContentType.JSON)
+                .queryParam("page", 1)
+                .queryParam("size", 15)
+                .queryParam("sort", "createdAt,desc")
+                .queryParam("sort", "id,desc")
+                .when()
+                .get("/spaces/%s/guestbook/unread".formatted(publicSpace.getCode()))
+                .then()
+                .statusCode(200)
+                .extract()
+                .body()
+                .as(new TypeRef<>() {
+                });
+
+            // then
+            assertAll(
+                () -> assertThat(result.data().newCount()).isNull(),
+                () -> assertThat(result.data().guestBookCards()).hasSize(1),
+                () -> assertThat(result.data().guestBookCards().getFirst().id()).isEqualTo(unreadCard.id()),
+                () -> assertThat(result.data().totalCount()).isOne()
+            );
+        }
     }
 
     @DisplayName("방명록 카드 조회")

--- a/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -299,12 +299,12 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .body("message", containsString("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다."));
         }
 
-        @DisplayName("호스트가 방명록을 조회할 경우 읽은 방명록만 반환하고 읽지 않은 방명록 수를 응답한다")
+        @DisplayName("호스트가 기본 버전 방명록을 조회할 경우 전체 방명록을 반환하고 읽지 않은 방명록 수를 응답하지 않는다")
         @Test
-        void hostReadGuestBookReturnsOnlyReadCardsAndUnreadCount() {
+        void hostReadGuestBookWithDefaultVersionKeepsLegacyResponse() {
             // given
             WriteGuestBookCardResponse readCard = writeGuestBookCard(publicSpace);
-            writeGuestBookCardWithNoPhoto(publicSpace);
+            WriteGuestBookCardResponse unreadCard = writeGuestBookCardWithNoPhoto(publicSpace);
             readGuestBookCardAsHost(publicSpace, readCard.id());
 
             // when, then
@@ -326,10 +326,12 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
 
             // then
             assertAll(
-                () -> assertThat(result.data().newCount()).isOne(),
-                () -> assertThat(result.data().guestBookCards()).hasSize(1),
-                () -> assertThat(result.data().guestBookCards().getFirst().id()).isEqualTo(readCard.id()),
-                () -> assertThat(result.data().totalCount()).isOne()
+                () -> assertThat(result.data().guestBookCards()).hasSize(2),
+                () -> assertThat(result.data().guestBookCards().getFirst().id()).isEqualTo(unreadCard.id()),
+                () -> assertThat(result.data().guestBookCards().getFirst().isRead()).isFalse(),
+                () -> assertThat(result.data().guestBookCards().getLast().id()).isEqualTo(readCard.id()),
+                () -> assertThat(result.data().guestBookCards().getLast().isRead()).isTrue(),
+                () -> assertThat(result.data().totalCount()).isEqualTo(2)
             );
         }
 
@@ -363,6 +365,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(result.data().newCount()).isNull(),
                 () -> assertThat(result.data().guestBookCards()).hasSize(1),
                 () -> assertThat(result.data().guestBookCards().getFirst().id()).isEqualTo(unreadCard.id()),
+                () -> assertThat(result.data().guestBookCards().getFirst().isRead()).isNull(),
                 () -> assertThat(result.data().totalCount()).isOne()
             );
         }
@@ -543,6 +546,7 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
 
             // then
             ApiResponse<GuestBookResponse> result = RestAssuredMockMvc.given()
+                .header("X-API-Version", "2")
                 .header("Authorization", "Bearer " + accessToken)
                 .accept(ContentType.JSON)
                 .queryParam("page", 1)

--- a/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
+++ b/src/test/java/com/forgather/acceptance/GuestBookCardAcceptanceTest.java
@@ -144,14 +144,14 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
             );
         }
 
-        @DisplayName("방문자가 공개 스페이스의 방명록을 조회할 경우 방명록 카드 읽음 여부는 알지 못한다")
+        @DisplayName("방문자가 공개 스페이스의 방명록을 조회할 경우 읽지 않은 방명록 개수는 알지 못한다")
         @Test
-        void guestCannotKnowIsCardRead() {
+        void guestCannotKnowUnreadCount() {
             // given
             writeGuestBookCard(publicSpace);
 
             // when
-            boolean result = RestAssuredMockMvc.given()
+            String response = RestAssuredMockMvc.given()
                 .accept(ContentType.JSON)
                 .queryParam("page", 1)
                 .queryParam("size", 15)
@@ -163,11 +163,10 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .statusCode(200)
                 .extract()
                 .body()
-                .asString()
-                .contains("\"isRead\"");
+                .asString();
 
             // then
-            assertThat(result).isFalse();
+            assertThat(response).doesNotContain("\"newCount\"");
         }
 
         @DisplayName("방문자 조회 시 방명록은 각 방명록 카드의 방문자 닉네임과 사진 여부를 포함한다")
@@ -201,11 +200,9 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(result.data().guestBookCards().getFirst().nickname()).isEqualTo(
                     writeResponseWithNoPhoto.nickname()),
                 () -> assertThat(result.data().guestBookCards().getFirst().containsPhoto()).isFalse(),
-                () -> assertThat(result.data().guestBookCards().getFirst().isRead()).isNull(),
                 () -> assertThat(result.data().guestBookCards().getLast().nickname()).isEqualTo(
                     writeResponse.nickname()),
                 () -> assertThat(result.data().guestBookCards().getLast().containsPhoto()).isTrue(),
-                () -> assertThat(result.data().guestBookCards().getLast().isRead()).isNull(),
                 () -> assertThat(result.data().currentPage()).isEqualTo(1),
                 () -> assertThat(result.data().pageSize()).isEqualTo(15),
                 () -> assertThat(result.data().totalCount()).isEqualTo(2),
@@ -302,14 +299,16 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .body("message", containsString("방문자는 비공개 스페이스의 방명록을 조회할 수 없습니다."));
         }
 
-        @DisplayName("호스트가 방명록을 조회할 경우 방명록 카드 읽음 여부를 알 수 있다")
+        @DisplayName("호스트가 방명록을 조회할 경우 읽은 방명록만 반환하고 읽지 않은 방명록 수를 응답한다")
         @Test
-        void hostCanKnowIsCardRead() {
+        void hostReadGuestBookReturnsOnlyReadCardsAndUnreadCount() {
             // given
-            writeGuestBookCard(publicSpace);
+            WriteGuestBookCardResponse readCard = writeGuestBookCard(publicSpace);
+            writeGuestBookCardWithNoPhoto(publicSpace);
+            readGuestBookCardAsHost(publicSpace, readCard.id());
 
-            // when
-            boolean result = RestAssuredMockMvc.given()
+            // when, then
+            ApiResponse<GuestBookResponse> result = RestAssuredMockMvc.given()
                 .header("Authorization", "Bearer " + accessToken)
                 .accept(ContentType.JSON)
                 .queryParam("page", 1)
@@ -322,12 +321,18 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
                 .statusCode(200)
                 .extract()
                 .body()
-                .asString()
-                .contains("\"isRead\"");
+                .as(new TypeRef<>() {
+                });
 
             // then
-            assertThat(result).isTrue();
+            assertAll(
+                () -> assertThat(result.data().newCount()).isOne(),
+                () -> assertThat(result.data().guestBookCards()).hasSize(1),
+                () -> assertThat(result.data().guestBookCards().getFirst().id()).isEqualTo(readCard.id()),
+                () -> assertThat(result.data().totalCount()).isOne()
+            );
         }
+
     }
 
     @DisplayName("방명록 카드 조회")
@@ -523,7 +528,8 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
             assertAll(
                 () -> assertThat(result.code()).isEqualTo(ResponseCode.SUCCESS),
                 () -> assertThat(result.message()).isNull(),
-                () -> assertThat(result.data().guestBookCards().getFirst().isRead()).isTrue()
+                () -> assertThat(result.data().newCount()).isZero(),
+                () -> assertThat(result.data().guestBookCards().getFirst().id()).isEqualTo(writeResponse.id())
             );
         }
     }
@@ -858,5 +864,15 @@ class GuestBookCardAcceptanceTest extends AcceptanceTest {
             .post("/spaces/{spaceCode}/guestbook/{guestBookCardId}/reports", space.getCode(), guestBookCardId)
             .then()
             .statusCode(201);
+    }
+
+    private void readGuestBookCardAsHost(Space space, Long guestBookCardId) {
+        RestAssuredMockMvc.given()
+            .header("Authorization", "Bearer " + accessToken)
+            .accept(ContentType.JSON)
+            .when()
+            .get("/spaces/%s/guestbook/%d".formatted(space.getCode(), guestBookCardId))
+            .then()
+            .statusCode(200);
     }
 }

--- a/src/test/java/com/forgather/domain/guestbook/service/GuestBookServiceTest.java
+++ b/src/test/java/com/forgather/domain/guestbook/service/GuestBookServiceTest.java
@@ -64,6 +64,7 @@ class GuestBookServiceTest {
 
     @DisplayName("방명록 목록 조회 시 숨김 처리되지 않은 방명록만 반환한다")
     @Test
+    @SuppressWarnings({"deprecation", "removal"})
     void readGuestBookExcludesHiddenCards() {
         // given
         GuestBookCard hiddenCard = guestBookCardRepository.save(createGuestBookCardWithSpace(space));


### PR DESCRIPTION
## 연관된 이슈

- close #107

## 작업 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 방명록 조회 API에 버전 관리 지원 추가( v2 헤더 기반)
  * 읽지 않은 방명록 조회 기능 추가
  * 방명록 응답에 읽지 않은 항목 개수(`unreadCount`) 필드 추가
* **지원 중단**
  * 기존 방명록 조회 엔드포인트는 더 이상 OpenAPI에 노출되지 않도록 처리(향후 제거 예정)
* **테스트**
  * 방명록 API 버전/응답 필드 노출 기준에 맞춰 테스트 갱신 및 검증 강화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->